### PR TITLE
add k3d cluster deployment example with static musl compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 **/*.rs.bk
 
 .idea
+
+.tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "containerd-shim",
  "containerd-shim-wasm",
  "log",
+ "openssl",
  "spin-engine",
  "spin-http-engine",
  "spin-loader",
@@ -2178,6 +2179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2196,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,18 @@ CONTAINERD_NAMESPACE ?= default
 build:
 	cargo build --release
 
+.PHONY: install-cross
+install-cross:
+	cargo install cross --git https://github.com/cross-rs/cross
+
+build-static-musl: install-cross
+	cross build --release --target x86_64-unknown-linux-musl
+
 .PHONY: install
 install: build
 	sudo $(INSTALL) target/release/containerd-shim-*-v1 $(PREFIX)/bin
 
+.PHONY: update-deps
 update-deps:
 	cargo update
 
@@ -23,9 +31,11 @@ test/out_spin/img.tar: images/spin/Dockerfile
 load: test/out_spin/img.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import test/out_spin/img.tar
 
+.PHONY: run_spin
 run_spin: install load
 	sudo ctr run --net-host --rm --runtime=io.containerd.spin.v1 docker.io/library/$(TEST_IMG_NAME_SPIN) testspin
 
+.PHONY: clean
 clean:
 	sudo rm -rf $(PREFIX)/bin/containerd-shim-spin-v1
 	sudo rm -rf ./test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ The "hello world" image contains only 2 files, the [`spin.toml`](./images/spin/s
 ### Cleaning up
 To clean up, run `make clean`.
 
+## Example Kubernetes Cluster Deployments
+In [the deployments directory](deployments) you will find examples of deploying the shims to Kubernetes clusters and using them in example Kubernetes workloads.
+
 ## Using a shim in Kubernetes
 To use one of these containerd shims in Kubernetes, you must do the following:
 1. Install the shim binary somewhere on the path of your Kubernetes worker nodes. For example, copy `containerd-shim-spin-v1` to  `/bin`.

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -18,4 +18,4 @@ spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v0.4.0"  }
 tokio = { version = "1", features = [ "rt" ] }
 tokio-util = { version = "0.6.10", features = [ "codec" ]}
 wasmtime = "^0.35"
-
+openssl = { version = "*", features = ["vendored"] }

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,0 +1,11 @@
+# Shim Deployment Examples
+This directory contains examples of how to deploy the shims.
+
+## K3ds Deployment
+[This deployment](k3d) uses k3d to deploy a local Kubernetes cluster. It illustrates how to customize the k3ds image that is deployed. The image used to run the k3ds Kubernetes nodes has the shims copied into the `/bin` directory and the containerd config updated to include runtime bindings for the shims.
+
+## Cluster API Deployment
+Coming soon...
+
+## Workloads
+In [the workloads directory](./workloads) you will find common workloads that we deploy to the clusters to register runtime classes and deploy Wasm enabled pod workloads.

--- a/deployments/k3d/Dockerfile
+++ b/deployments/k3d/Dockerfile
@@ -1,0 +1,7 @@
+FROM rancher/k3s:v1.24.4-k3s1-amd64
+
+# copy shims from target directory into the /bin
+COPY ./.tmp /bin/
+
+# copy in an containerd config into /etc/containerd/config.toml
+COPY config.toml.tmpl /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl

--- a/deployments/k3d/Makefile
+++ b/deployments/k3d/Makefile
@@ -1,0 +1,25 @@
+IMAGE_NAME ?= k3swithshims
+CLUSTER_NAME ?= k3s-default
+
+build:
+	make build-static-musl -C ../../
+	mkdir -p ./.tmp
+	cp ../../target/x86_64-unknown-linux-musl/release/containerd-shim-*-v1 ./.tmp/
+	docker build -t $(IMAGE_NAME) .
+
+up: build
+	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer"
+
+deploy: 
+	kubectl apply -f ../workloads
+
+test:
+	curl localhost:8081/hello
+
+clean: 
+	k3d cluster delete $(CLUSTER_NAME)
+
+install-k3d:
+	wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+.PHONY: deploy clean test build install-k3d up

--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -1,0 +1,22 @@
+# K3d Shim Deployment
+This example shows how one could deploy the shims and use them locally using k3d. The example consists of the following files.
+
+```
+$ tree .
+.
+├── config.toml.tmpl
+├── Dockerfile
+├── Makefile
+└── README.md
+```
+
+- **config.toml.tmpl:** is the containerd config template that k3d uses to generate the containerd config. We have added a line to the template to register the shims, so that containerd will understand how to run our Wasm pod's runtime class.
+- **Dockerfile:** is the specification for the image run as a Kubernetes node within the k3d cluster. We add the shims to the `/bin` directory and add the containerd config in the k3s prescribed directory.
+- **Makefile**: has some helpful tasks to aid in execution.
+
+## How to use this example
+- `make install-k3d`: will install k3d
+- `make up`: will build the shims and the k3d kubernetes cluster
+- `make deploy`: will deploy our runtime classes, services, and deployments of Wasm workloads. You can find these manifests in [the workloads directory](../workloads).
+- `make test`: will make a curl call to our deployed service
+- `make clean`: will tear down the cluster

--- a/deployments/k3d/config.toml.tmpl
+++ b/deployments/k3d/config.toml.tmpl
@@ -1,0 +1,106 @@
+[plugins.opt]
+  path = "{{ .NodeConfig.Containerd.Opt }}"
+[plugins.cri]
+  stream_server_address = "127.0.0.1"
+  stream_server_port = "10010"
+  enable_selinux = {{ .NodeConfig.SELinux }}
+{{- if .DisableCgroup}}
+  disable_cgroup = true
+{{end}}
+{{- if .IsRunningInUserNS }}
+  disable_apparmor = true
+  restrict_oom_score_adj = true
+{{end}}
+{{- if .NodeConfig.AgentConfig.PauseImage }}
+  sandbox_image = "{{ .NodeConfig.AgentConfig.PauseImage }}"
+{{end}}
+{{- if .NodeConfig.AgentConfig.Snapshotter }}
+[plugins.cri.containerd]
+  snapshotter = "{{ .NodeConfig.AgentConfig.Snapshotter }}"
+  disable_snapshot_annotations = {{ if eq .NodeConfig.AgentConfig.Snapshotter "stargz" }}false{{else}}true{{end}}
+{{ if eq .NodeConfig.AgentConfig.Snapshotter "stargz" }}
+{{ if .NodeConfig.AgentConfig.ImageServiceSocket }}
+[plugins.stargz]
+cri_keychain_image_service_path = "{{ .NodeConfig.AgentConfig.ImageServiceSocket }}"
+[plugins.stargz.cri_keychain]
+enable_keychain = true
+{{end}}
+{{ if .PrivateRegistryConfig }}
+{{ if .PrivateRegistryConfig.Mirrors }}
+[plugins.stargz.registry.mirrors]{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Mirrors }}
+[plugins.stargz.registry.mirrors."{{$k}}"]
+  endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
+{{if $v.Rewrites}}
+  [plugins.stargz.registry.mirrors."{{$k}}".rewrite]
+{{range $pattern, $replace := $v.Rewrites}}
+    "{{$pattern}}" = "{{$replace}}"
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Configs }}
+{{ if $v.Auth }}
+[plugins.stargz.registry.configs."{{$k}}".auth]
+  {{ if $v.Auth.Username }}username = {{ printf "%q" $v.Auth.Username }}{{end}}
+  {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
+  {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
+  {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
+{{end}}
+{{ if $v.TLS }}
+[plugins.stargz.registry.configs."{{$k}}".tls]
+  {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
+  {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
+  {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
+  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{- if not .NodeConfig.NoFlannel }}
+[plugins.cri.cni]
+  bin_dir = "{{ .NodeConfig.AgentConfig.CNIBinDir }}"
+  conf_dir = "{{ .NodeConfig.AgentConfig.CNIConfDir }}"
+{{end}}
+[plugins.cri.containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+{{ if .PrivateRegistryConfig }}
+{{ if .PrivateRegistryConfig.Mirrors }}
+[plugins.cri.registry.mirrors]{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Mirrors }}
+[plugins.cri.registry.mirrors."{{$k}}"]
+  endpoint = [{{range $i, $j := $v.Endpoints}}{{if $i}}, {{end}}{{printf "%q" .}}{{end}}]
+{{if $v.Rewrites}}
+  [plugins.cri.registry.mirrors."{{$k}}".rewrite]
+{{range $pattern, $replace := $v.Rewrites}}
+    "{{$pattern}}" = "{{$replace}}"
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .PrivateRegistryConfig.Configs }}
+{{ if $v.Auth }}
+[plugins.cri.registry.configs."{{$k}}".auth]
+  {{ if $v.Auth.Username }}username = {{ printf "%q" $v.Auth.Username }}{{end}}
+  {{ if $v.Auth.Password }}password = {{ printf "%q" $v.Auth.Password }}{{end}}
+  {{ if $v.Auth.Auth }}auth = {{ printf "%q" $v.Auth.Auth }}{{end}}
+  {{ if $v.Auth.IdentityToken }}identitytoken = {{ printf "%q" $v.Auth.IdentityToken }}{{end}}
+{{end}}
+{{ if $v.TLS }}
+[plugins.cri.registry.configs."{{$k}}".tls]
+  {{ if $v.TLS.CAFile }}ca_file = "{{ $v.TLS.CAFile }}"{{end}}
+  {{ if $v.TLS.CertFile }}cert_file = "{{ $v.TLS.CertFile }}"{{end}}
+  {{ if $v.TLS.KeyFile }}key_file = "{{ $v.TLS.KeyFile }}"{{end}}
+  {{ if $v.TLS.InsecureSkipVerify }}insecure_skip_verify = true{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{range $k, $v := .ExtraRuntimes}}
+[plugins.cri.containerd.runtimes."{{$k}}"]
+  runtime_type = "{{$v.RuntimeType}}"
+[plugins.cri.containerd.runtimes."{{$k}}".options]
+  BinaryName = "{{$v.BinaryName}}"
+{{end}}
+
+[plugins.cri.containerd.runtimes.spin]
+  runtime_type = "io.containerd.spin.v1"
+

--- a/deployments/workloads/runtime.yml
+++ b/deployments/workloads/runtime.yml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasmtime-spin
+handler: spin

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasm-spin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wasm-spin
+  template:
+    metadata:
+      labels:
+        app: wasm-spin
+    spec:
+      runtimeClassName: wasmtime-spin
+      containers:
+        - name: testwasm
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:latest
+          command: ["/"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasm-service
+spec:
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: wasm-spin


### PR DESCRIPTION
- add static compilation for musl so that we can run it on the k3d base image
- add examples and documentation on how to deploy the shims
- add a deployment mechanism that can be used for multiple shims and K8s workloads