### PR TITLE
dry up build and add release for k3d demo image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: build
+on:
+  workflow_call:
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+      - name: build
+        run: make
+      - name: build k3d demo
+        run: make build-image
+        working-directory: ./deployments/k3d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,4 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: build
-        run: make
+    uses: ./.github/workflows/build.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,8 @@ on:
       - 'v[0-9]+.[0-9]+.*'
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: build
-        run: make
+    # run ci prior to release
+    uses: ./.github/workflows/build.yaml
   release:
     permissions: 
       contents: write
@@ -49,21 +39,14 @@ jobs:
           cp target/release/containerd-shim-*-v1 _dist/
           cd _dist
           tar czf containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-amd64.tar.gz containerd-shim-*-v1
-      - name: upload binary as GitHub artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: containerd-wasm-shims-v1
-          path: _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-amd64.tar.gz
-      - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.10.0
-        with:
-          tag: ${{ env.RELEASE_VERSION }}
-          allowUpdates: true
-          prerelease: true
-          artifacts: _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-amd64.tar.gz
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features, some of which may not be fully implemented.
+      - name: create release
+        run: |
+          gh release create ${{ env.RELEASE_VERSION }} \
+            --generate-notes \
+            -p \
+            _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-amd64.tar.gz#containerd-wasm-shims-v1 \
+            ./deployments/workloads/runtime.yml#example-runtimes \
+            ./deployments/workloads/workload.yml#example-workloads
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry
@@ -80,6 +63,14 @@ jobs:
             ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:${{ env.RELEASE_VERSION }}
             ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:latest
           context: images/spin
+      - name: build and push k3d shim image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:${{ env.RELEASE_VERSION }}
+            ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:latest
+          context: deployments/k3d
       - name: clear
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ build:
 
 .PHONY: install-cross
 install-cross:
-	cargo install cross --git https://github.com/cross-rs/cross
+	@if [ -z $$(which cross) ]; then cargo install cross --git https://github.com/cross-rs/cross; fi
 
-build-static-musl: install-cross
-	cross build --release --target x86_64-unknown-linux-musl
+# build-cross can be be used to build any cross supported target (make build-cross-x86_64-unknown-linux-musl)
+.PHONY: build-cross-%
+build-cross-%: install-cross
+	cross build --release --target $*
 
 .PHONY: install
 install: build

--- a/deployments/k3d/Makefile
+++ b/deployments/k3d/Makefile
@@ -1,13 +1,17 @@
 IMAGE_NAME ?= k3swithshims
 CLUSTER_NAME ?= k3s-default
 
-build:
-	make build-static-musl -C ../../
+compile-musl:
+	make build-cross-x86_64-unknown-linux-musl -C ../..
+
+move-musl-to-tmp: compile-musl
 	mkdir -p ./.tmp
 	cp ../../target/x86_64-unknown-linux-musl/release/containerd-shim-*-v1 ./.tmp/
+
+build-image: move-musl-to-tmp
 	docker build -t $(IMAGE_NAME) .
 
-up: build
+up: build-image
 	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer"
 
 deploy: 
@@ -22,4 +26,4 @@ clean:
 install-k3d:
 	wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
-.PHONY: deploy clean test build install-k3d up
+.PHONY: deploy clean test build-image install-k3d up compile-musl move-musl-to-tmp


### PR DESCRIPTION
- reuse build workflow for both ci and release
- add a cross compilation workflow that can be called with input
- add release and build workflow steps to produce the k3d demo image