### PR TITLE
fix release workflow and relax cache key lookup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
             ./target/
             ./deployments/k3d/.tmp/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: build
         run: make
       - name: build k3d demo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
             --generate-notes \
             -p \
             _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-amd64.tar.gz#containerd-wasm-shims-v1 \
-            ./deployments/workloads/runtime.yml#example-runtimes \
-            ./deployments/workloads/workload.yml#example-workloads
+            ./deployments/workloads/runtime.yaml#example-runtimes \
+            ./deployments/workloads/workload.yaml#example-workloads
       - name: setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry


### PR DESCRIPTION
- fix 'yml' endings for artifacts in the release workflow
- relax the cache key constrain for the build job