### PR TITLE
fix workload to run with traefik in k3d

### DIFF
--- a/deployments/k3d/Makefile
+++ b/deployments/k3d/Makefile
@@ -12,7 +12,7 @@ build-image: move-musl-to-tmp
 	docker build -t $(IMAGE_NAME) .
 
 up: build-image
-	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer"
+	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer" --agents 2
 
 deploy: 
 	kubectl apply -f ../workloads

--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -17,7 +17,7 @@ $ tree .
 ## How to run the example
 The shell script below will create a k3d cluster locally with the Wasm shims installed and containerd configured. The script then applies the runtime classes for the shims and an example service and deployment. Finally, we curl the `/hello` and receive a response from the example workload.
 ```shell
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:latest --api-port 6550 -p "8081:80@loadbalancer"
+k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:latest -p "8081:80@loadbalancer" --agents 2
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.0/runtime.yaml
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.0/workload.yaml
 curl -v http://0.0.0.0:8081/hello

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: wasm-spin
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: wasm-spin
@@ -21,7 +21,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: wasm-service
+  name: wasm-spin
 spec:
   type: LoadBalancer
   ports:
@@ -30,3 +30,22 @@ spec:
       targetPort: 80
   selector:
     app: wasm-spin
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasm-spin
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wasm-spin
+                port:
+                  number: 80


### PR DESCRIPTION
- add traefik ingress for the workload
- remove sulfurous `--api-port` flag
- add a couple k3d agents for fun 