### PR TITLE
remove service type lb from example workload

### DIFF
--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -18,8 +18,8 @@ $ tree .
 The shell script below will create a k3d cluster locally with the Wasm shims installed and containerd configured. The script then applies the runtime classes for the shims and an example service and deployment. Finally, we curl the `/hello` and receive a response from the example workload.
 ```shell
 k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:latest -p "8081:80@loadbalancer" --agents 2
-kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.1/runtime.yaml
-kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.1/workload.yaml
+kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.2/runtime.yaml
+kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.2.2/workload.yaml
 curl -v http://0.0.0.0:8081/hello
 ```
 

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -23,7 +23,6 @@ kind: Service
 metadata:
   name: wasm-spin
 spec:
-  type: LoadBalancer
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
- removed service type loadbalancer from the example workload as traefik needs ClusterIP to work correctly