### PR TITLE
feat(slight-shim): mount the shim's resolv.conf to host's

### DIFF
--- a/containerd-shim-slight-v1/Cargo.lock
+++ b/containerd-shim-slight-v1/Cargo.lock
@@ -1190,7 +1190,6 @@ dependencies = [
  "log",
  "openssl",
  "slight",
- "spiderlightning",
  "tokio",
  "tokio-util 0.6.10",
  "toml",
@@ -3940,7 +3939,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slight"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "as-any",
@@ -3968,10 +3967,11 @@ dependencies = [
 [[package]]
 name = "slight-common"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "as-any",
+ "async-trait",
  "slight-events-api",
  "slight-http-api",
  "wasmtime",
@@ -3980,11 +3980,12 @@ dependencies = [
 [[package]]
 name = "slight-events"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
  "crossbeam-utils",
+ "futures",
  "slight-common",
  "slight-events-api",
  "tracing",
@@ -3998,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "slight-events-api"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "cloudevents-sdk",
@@ -4009,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "slight-http"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -4030,9 +4031,10 @@ dependencies = [
 [[package]]
 name = "slight-http-api"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
+ "async-trait",
  "hyper",
  "wasmtime",
  "wit-bindgen-wasmtime 0.2.0 (git+https://github.com/Mossaka/wit-bindgen?rev=6f80d65a483fe929a79e2661825d99842227b146)",
@@ -4042,9 +4044,10 @@ dependencies = [
 [[package]]
 name = "slight-kv"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-sdk-dynamodb",
  "azure_core 0.4.0",
@@ -4060,6 +4063,7 @@ dependencies = [
  "slight-common",
  "slight-events-api",
  "slight-runtime-configs",
+ "tokio",
  "tracing",
  "uuid 1.1.2",
  "wit-bindgen-wasmtime 0.2.0 (git+https://github.com/bytecodealliance/wit-bindgen?tag=v0.2.0)",
@@ -4069,12 +4073,12 @@ dependencies = [
 [[package]]
 name = "slight-lockd"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
+ "async-trait",
  "crossbeam-channel",
  "etcd-client",
- "futures",
  "slight-common",
  "slight-events-api",
  "slight-runtime-configs",
@@ -4089,18 +4093,19 @@ dependencies = [
 [[package]]
 name = "slight-mq"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
+ "async-trait",
  "azure_core 0.2.2",
  "azure_messaging_servicebus",
  "chrono",
  "crossbeam-channel",
- "futures",
  "http",
  "slight-common",
  "slight-events-api",
  "slight-runtime-configs",
+ "tokio",
  "tracing",
  "url",
  "uuid 1.1.2",
@@ -4111,16 +4116,18 @@ dependencies = [
 [[package]]
 name = "slight-pubsub"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "async-channel",
+ "async-trait",
  "crossbeam-channel",
  "futures",
  "mosquitto-rs",
  "slight-common",
  "slight-events-api",
  "slight-runtime-configs",
+ "tokio",
  "tracing",
  "url",
  "uuid 1.1.2",
@@ -4131,10 +4138,11 @@ dependencies = [
 [[package]]
 name = "slight-runtime"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "as-any",
+ "async-trait",
  "crossbeam-channel",
  "dyn-clone",
  "slight-common",
@@ -4158,12 +4166,12 @@ dependencies = [
 [[package]]
 name = "slight-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
+ "async-trait",
  "azure-app-configuration",
  "crossbeam-channel",
- "futures",
  "rand 0.8.5",
  "short-crypt",
  "slight-common",
@@ -4227,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "spiderlightning"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5639,6 +5647,7 @@ version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?tag=v0.2.0#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags",
  "thiserror",
  "wasmtime",
@@ -5651,6 +5660,7 @@ version = "0.2.0"
 source = "git+https://github.com/Mossaka/wit-bindgen?rev=6f80d65a483fe929a79e2661825d99842227b146#6f80d65a483fe929a79e2661825d99842227b146"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bitflags",
  "thiserror",
  "wasmtime",

--- a/containerd-shim-slight-v1/Cargo.lock
+++ b/containerd-shim-slight-v1/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "containerd-shim",
  "containerd-shim-wasm",
  "log",
+ "nix 0.25.0",
  "openssl",
  "slight",
  "tokio",

--- a/containerd-shim-slight-v1/Cargo.lock
+++ b/containerd-shim-slight-v1/Cargo.lock
@@ -1188,7 +1188,6 @@ dependencies = [
  "containerd-shim",
  "containerd-shim-wasm",
  "log",
- "nix 0.25.0",
  "openssl",
  "slight",
  "tokio",

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -18,8 +18,7 @@ wasmtime = "0.39"
 toml = "0.5"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
-slight = { git = "https://github.com/deislabs/spiderlightning", rev = "d029c57d20485b6cade1635827d66364e36de9fe"}
-spiderlightning = { git = "https://github.com/deislabs/spiderlightning", rev = "d029c57d20485b6cade1635827d66364e36de9fe"}
+slight = { git = "https://github.com/deislabs/spiderlightning", rev = "732acf471c8a4225b0333ee5b2085e0aaf2ef892"}
 openssl = { version = "0.10", features = ["vendored"] }
 
 [workspace]

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -20,6 +20,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
 slight = { git = "https://github.com/deislabs/spiderlightning", rev = "732acf471c8a4225b0333ee5b2085e0aaf2ef892"}
 openssl = { version = "0.10", features = ["vendored"] }
-nix = { version = "0.25", features = ["mount"] }
 
 [workspace]

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -20,5 +20,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1", features = ["log"] }
 slight = { git = "https://github.com/deislabs/spiderlightning", rev = "732acf471c8a4225b0333ee5b2085e0aaf2ef892"}
 openssl = { version = "0.10", features = ["vendored"] }
+nix = { version = "0.25", features = ["mount"] }
 
 [workspace]

--- a/containerd-shim-slight-v1/src/main.rs
+++ b/containerd-shim-slight-v1/src/main.rs
@@ -14,7 +14,6 @@ use containerd_shim_wasm::sandbox::Instance;
 use containerd_shim_wasm::sandbox::instance::EngineGetter;
 use containerd_shim_wasm::sandbox::oci;
 use log::info;
-use nix::mount::{mount, MsFlags};
 
 use tokio::runtime::Runtime;
 use slight_lib::commands::run::handle_run;
@@ -42,15 +41,10 @@ pub fn prepare_module(bundle: String) -> Result<(PathBuf, PathBuf), Error> {
     
 
     let working_dir = oci::get_root(&spec);
-    
-    // mount the resolv.conf to the host resolv.conf
-    mount::<str, str, str, str>(
-        Some(working_dir.join("etc/resolv.conf").to_str().unwrap()),
-        "/etc/resolv.conf",
-        Some("bind"),
-        MsFlags::MS_BIND,
-        None,
-    ).unwrap();
+
+    // change the working directory to the rootfs
+    std::os::unix::fs::chroot(working_dir).unwrap();
+    std::env::set_current_dir("/").unwrap();
 
     // add env to current proc
     let env = spec
@@ -67,8 +61,8 @@ pub fn prepare_module(bundle: String) -> Result<(PathBuf, PathBuf), Error> {
         };
     }
 
-    let mod_path = working_dir.join("slightfile.toml");
-    let wasm_path = working_dir.join("app.wasm");
+    let mod_path = PathBuf::from("slightfile.toml");
+    let wasm_path = PathBuf::from("app.wasm");
     Ok((wasm_path, mod_path))
 }
 

--- a/deployments/k3d/Makefile
+++ b/deployments/k3d/Makefile
@@ -16,7 +16,7 @@ build-image: move-musl-to-tmp
 	docker build -t $(IMAGE_NAME) .
 
 up: build-image
-	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer" --agents 2
+	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer" --agents 1
 
 deploy-spin: 
 	kubectl apply -f ../workloads/spin

--- a/deployments/workloads/slight/workload.yaml
+++ b/deployments/workloads/slight/workload.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: wasm-slight
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: wasm-slight
@@ -15,22 +15,8 @@ spec:
       runtimeClassName: wasmtime-slight
       containers:
         - name: testwasm
-          image: docker.io/mossaka/slight-try3:awsdynamodb
+          image: docker.io/mossaka/slight-try:filesystem
           command: ["/"]
-          envFrom:
-          - secretRef:
-              name: aws-credentials
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-credentials
-type: Opaque
-stringData:
-  AWS_ACCESS_KEY_ID: 
-  AWS_SECRET_ACCESS_KEY:
-  AWS_DEFAULT_REGION:
-  AWS_REGION:
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/workloads/slight/workload.yaml
+++ b/deployments/workloads/slight/workload.yaml
@@ -15,8 +15,22 @@ spec:
       runtimeClassName: wasmtime-slight
       containers:
         - name: testwasm
-          image: docker.io/mossaka/slight-try:latest
+          image: docker.io/mossaka/slight-try2:awsdynamodb
           command: ["/"]
+          envFrom:
+          - secretRef:
+              name: aws-credentials
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: 
+  AWS_SECRET_ACCESS_KEY:
+  AWS_DEFAULT_REGION:
+  AWS_REGION:
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/workloads/slight/workload.yaml
+++ b/deployments/workloads/slight/workload.yaml
@@ -15,7 +15,7 @@ spec:
       runtimeClassName: wasmtime-slight
       containers:
         - name: testwasm
-          image: docker.io/mossaka/slight-try2:awsdynamodb
+          image: docker.io/mossaka/slight-try3:awsdynamodb
           command: ["/"]
           envFrom:
           - secretRef:

--- a/images/slight/Cargo.lock
+++ b/images/slight/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 [[package]]
 name = "slight-http-handler-macro"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?rev=d029c57d20485b6cade1635827d66364e36de9fe#d029c57d20485b6cade1635827d66364e36de9fe"
+source = "git+https://github.com/deislabs/spiderlightning?rev=732acf471c8a4225b0333ee5b2085e0aaf2ef892#732acf471c8a4225b0333ee5b2085e0aaf2ef892"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/images/slight/Cargo.toml
+++ b/images/slight/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 anyhow = "1"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", tag = "v0.2.0" }
 wit-error-rs = { git = "https://github.com/danbugs/wit-error-rs", rev = "05362f1a4a3a9dc6a1de39195e06d2d5d6491a5e" }
-slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", rev = "d029c57d20485b6cade1635827d66364e36de9fe"}
+slight-http-handler-macro = { git = "https://github.com/deislabs/spiderlightning", rev = "732acf471c8a4225b0333ee5b2085e0aaf2ef892"}
 
 [workspace]

--- a/images/slight/Dockerfile
+++ b/images/slight/Dockerfile
@@ -2,7 +2,9 @@ FROM rust:1.64 AS build
 WORKDIR /opt/build
 COPY . .
 RUN rustup target add wasm32-wasi && cargo build --target wasm32-wasi --release
+RUN apt-get update && apt-get install ca-certificates -y
 
 FROM scratch
 COPY --from=build /opt/build/target/wasm32-wasi/release/slight.wasm ./app.wasm
 COPY --from=build /opt/build/slightfile.toml .
+COPY --from=build /etc/ssl /etc/ssl

--- a/images/slight/Dockerfile
+++ b/images/slight/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59 AS build
+FROM rust:1.64 AS build
 WORKDIR /opt/build
 COPY . .
 RUN rustup target add wasm32-wasi && cargo build --target wasm32-wasi --release

--- a/images/slight/kv.wit
+++ b/images/slight/kv.wit
@@ -1,0 +1,20 @@
+// A key-value store interface.
+use { error, payload } from types
+use { observable } from resources
+
+resource kv {
+	// open a key-value store
+	static open: func(name: string) -> expected<kv, error>
+
+	// get the payload for a given key.
+	get: func(key: string) -> expected<payload, error> 
+
+	// set the payload for a given key.
+	set: func(key: string, value: payload) -> expected<unit, error>
+
+	// delete the payload for a given key.
+	delete: func(key:string) -> expected<unit, error>
+
+	// watch for changes to a key.
+	watch: func(key: string) -> expected<observable, error>
+}

--- a/images/slight/resources.wit
+++ b/images/slight/resources.wit
@@ -1,0 +1,4 @@
+record observable {
+	rd: string,
+	key: string,
+}

--- a/images/slight/slightfile.toml
+++ b/images/slight/slightfile.toml
@@ -1,4 +1,8 @@
 specversion = "0.1"
+secret_store = "configs.envvars"
 
 [[capability]]
 name = "http"
+
+[[capability]]
+name = "kv.awsdynamodb"

--- a/images/slight/slightfile.toml
+++ b/images/slight/slightfile.toml
@@ -5,4 +5,4 @@ secret_store = "configs.envvars"
 name = "http"
 
 [[capability]]
-name = "kv.awsdynamodb"
+name = "kv.filesystem"

--- a/images/slight/src/main.rs
+++ b/images/slight/src/main.rs
@@ -49,7 +49,6 @@ fn handle_foo(request: Request) -> Result<Response, Error> {
 #[register_handler]
 fn handle_bar(request: Request) -> Result<Response, Error> {
     assert_eq!(request.method, Method::Put);
-    println!("request body: {:?}", request.body);
     if let Some(body) = request.body {
         let kv = crate::Kv::open("my-container").unwrap();
         kv.set("key", &body).unwrap();

--- a/images/slight/src/main.rs
+++ b/images/slight/src/main.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 
 use http::*;
+use kv::*;
 use slight_http_handler_macro::register_handler;
 
 wit_bindgen_rust::import!("http.wit");
-wit_error_rs::impl_error!(Error);
+wit_bindgen_rust::import!("kv.wit");
+wit_error_rs::impl_error!(http::Error);
+wit_error_rs::impl_error!(kv::Error);
 
 fn main() -> Result<()> {
     let router = Router::new()?;
@@ -34,9 +37,11 @@ fn handle_hello(req: Request) -> Result<Response, Error> {
 
 #[register_handler]
 fn handle_foo(request: Request) -> Result<Response, Error> {
+    let kv = crate::Kv::open("my-container").unwrap();
+    let value = kv.get("key").unwrap();
     Ok(Response {
         headers: Some(request.headers),
-        body: request.body,
+        body: Some(value),
         status: 500,
     })
 }
@@ -44,9 +49,14 @@ fn handle_foo(request: Request) -> Result<Response, Error> {
 #[register_handler]
 fn handle_bar(request: Request) -> Result<Response, Error> {
     assert_eq!(request.method, Method::Put);
+    println!("request body: {:?}", request.body);
+    if let Some(body) = request.body {
+        let kv = crate::Kv::open("my-container").unwrap();
+        kv.set("key", &body).unwrap();
+    }
     Ok(Response {
         headers: Some(request.headers),
-        body: request.body,
+        body: None,
         status: 200,
     })
 }


### PR DESCRIPTION
This PR mounts the shim's resolv.conf to host's, so that the shim can use host's nameserver to do dns resolution. A consequence of this PR is that we can use outbound-http in our shim, and thus each http handler can read/write to external services such as AWS DynamoDB.