### PR TITLE
add ./bin to the cache path to be shared between jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
             ~/.cargo/git/db/
             ./target/
             ./deployments/k3d/.tmp/
+            ./bin
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
             ~/.cargo/git/db/
             ./target/
             ./deployments/k3d/.tmp/
+            ./bin
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: package release assets
         run: |


### PR DESCRIPTION
The build job moved the bins to ./bin. These artifacts are needed in the release build and can only be shared by persisting them across jobs. This PR adds ./bin to the cache path.