### PR TITLE
Enable CodeSpaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+  {
+    "name": "Codespace to bootstrap k3d in a Codespace",
+    "image": "mcr.microsoft.com/vscode/devcontainers/universal:linux",
+    "remoteUser": "codespace",
+      "overrideCommand": false,
+      "mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
+      "runArgs": [
+          "--cap-add=SYS_PTRACE",
+          "--security-opt",
+          "seccomp=unconfined",
+          "--privileged",
+          "--init"
+      ],
+      
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+          "GitHub.vscode-pull-request-github",
+          "ms-vscode.azure-account",
+          "ms-vscode.azurecli",
+          "ms-azuretools.vscode-docker",
+      ],
+      "postAttachCommand": "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+  }


### PR DESCRIPTION
This PR adds a basic devcontainer configuration that can be used to start a GitHub CodeSpace for containerd-shim testing via the k3d deployment instructions. Users can start a codespace using this configuration and the follow the k3d shim deployment steps to get a running k3d cluster with the shim installed.