### PR TITLE
refactor build to use artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: upload shim artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          name: containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           retention-days: 5
       - name: build k3d demo

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,14 +21,6 @@ jobs:
       ARCH: ${{ matrix.config.arch }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./deployments/k3d/.tmp/
-            ./bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -41,9 +33,20 @@ jobs:
       - name: build
         run: |
           make build
-          rm -rf ./bin && mkdir ./bin
-          cp containerd-shim-slight-v1/target/release/containerd-shim-*-v1 bin/
-          cp containerd-shim-spin-v1/target/release/containerd-shim-*-v1 bin/
+          cp containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 ./bin/${{ matrix.config.arch }}/
+          cp containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 ./bin/${{ matrix.config.arch }}/
+      - name: upload slight artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.arch }}-containerd-shim-slight-v1
+          path: containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1
+          retention-days: 5
+      - name: upload spin artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.arch }}-containerd-shim-spin-v1
+          path: containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1
+          retention-days: 5
       - name: build k3d demo
         run: make build-image
         working-directory: ./deployments/k3d

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,17 +33,18 @@ jobs:
       - name: build
         run: |
           make build
-      - name: upload slight artifact
+      - name: package release assets
+        run: |
+          mkdir _dist
+          cp containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
+          cp containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
+          cd _dist
+          tar czf containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
+      - name: upload shim artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.config.arch }}-containerd-shim-slight-v1
-          path: containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1
-          retention-days: 5
-      - name: upload spin artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.config.arch }}-containerd-shim-spin-v1
-          path: containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1
+          name: ${{ matrix.config.arch }}-containerd-shims-v1
+          path: _dist/containerd-shim-*-v1.tar.gz
           retention-days: 5
       - name: build k3d demo
         run: make build-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       ARCH: ${{ matrix.config.arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: upload shim artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.config.arch }}-containerd-shims-v1
-          path: _dist/containerd-shim-*-v1.tar.gz
+          name: containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          path: _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           retention-days: 5
       - name: build k3d demo
         run: make build-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,18 +33,23 @@ jobs:
       - name: build
         run: |
           make build
+      - name: lowercase the runner OS name
+        shell: bash
+        run: |
+          OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          echo "RUNNER_OS=$OS" >> $GITHUB_ENV
       - name: package release assets
         run: |
           mkdir _dist
           cp containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
           cp containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
           cd _dist
-          tar czf containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
+          tar czf containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
       - name: upload shim artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          path: _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          name: containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          path: _dist/containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           retention-days: 5
       - name: build k3d demo
         run: make build-image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,25 +6,13 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-
   release:
-    strategy:
-      matrix:
-        config:
-          - {
-              os: "ubuntu-latest",
-              arch: "x86_64",
-            }
-          - {
-              os: "ubuntu-latest",
-              arch: "aarch64"
-            }
     permissions: 
       contents: write
       packages: write 
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set RELEASE_VERSION ENV var
@@ -34,24 +22,15 @@ jobs:
         run: |
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=$OS" >> $GITHUB_ENV
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./deployments/k3d/.tmp/
-            ./bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: package release assets
-        run: |
-          mkdir _dist
-          cp bin/containerd-shim-*-v1 _dist/
-          cd _dist
-          tar czf containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
       - name: copy release workload assets into _dist
         run: |
           cp ./deployments/workloads/spin/runtime.yaml _dist/spin_runtime.yaml
           cp ./deployments/workloads/spin/workload.yaml _dist/spin_workload.yaml
           cp ./deployments/workloads/slight/runtime.yaml _dist/slight_runtime.yaml
           cp ./deployments/workloads/slight/workload.yaml _dist/slight_workload.yaml
+      - uses: actions/download-artifact@v3
+        with:
+          path: _artifacts
       - name: create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,11 +38,12 @@ jobs:
           gh release create ${{ env.RELEASE_VERSION }} \
             --generate-notes \
             -p \
-            _dist/containerd-wasm-shims-v1-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz#containerd-wasm-shims-v1 \
             _dist/spin_runtime.yaml#example-spin-runtimes \
             _dist/spin_workload.yaml#example-spin-workloads \
             _dist/slight_runtime.yaml#example-slight-runtimes \
             _dist/slight_workload.yaml#example-slight-workloads
+          
+          for f in ./_artifacts/*/*.tar.gz; do gh release upload ${{ env.RELEASE_VERSION }} $f; done
       - name: setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry
@@ -88,6 +68,11 @@ jobs:
             ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:${{ env.RELEASE_VERSION }}
             ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:latest
           context: images/slight
+      - name: untar x86_64 musl artifacts into ./deployments/k3d/.tmp dir
+        run: |
+          mkdir -p ./deployments/k3d/.tmp
+          tar -xf ./_artifacts/containerd-wasm-shims-v1-linux-x86_64/containerd-wasm-shims-v1-linux-x86_64.tar.gz \
+            --directory ./deployments/k3d/.tmp
       - name: build and push k3d shim image
         uses: docker/build-push-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@ PREFIX ?= /usr/local
 INSTALL ?= install
 TEST_IMG_NAME_SPIN ?= wasmtest_spin:latest
 TEST_IMG_NAME_SLIGHT ?= wasmtest_slight:latest
+ARCH ?= x86_64
+TARGET ?= $(ARCH)-unknown-linux-musl
 
 CONTAINERD_NAMESPACE ?= default
 
 .PHONY: build
-build: build-spin build-slight
+build: build-spin-cross-$(TARGET) build-slight-cross-$(TARGET)
 	echo "Build complete"
 
 .PHONY: build-spin


### PR DESCRIPTION
- build no longer shares a cache across jobs
- use artifacts to persist build artifacts across jobs
- change make to use cross by default, but also leave existing `make build` tasks
- release no long depends on cache, but rather, uses artifacts produced from the build.yaml