### PR TITLE
Chore: bump version to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "containerd-wasm-shims-tests"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "curl",
+ "http",
+ "hyper",
+ "k8s-openapi",
+ "kube",
+ "rand",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,21 +1242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "curl",
- "http",
- "hyper",
- "k8s-openapi",
- "kube",
- "rand",
- "tokio",
- "tower",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tests"
-version = "0.1.0"
+name = "containerd-wasm-shims-tests"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -3,8 +3,12 @@ name = "containerd-shim-slight-v1"
 version = "0.4.0"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository = 'https://github.com/deislabs/containerd-wasm-shims'
+license = "Apache-2.0"
+homepage = 'https://github.com/deislabs/containerd-wasm-shims'
+description = """
+Containerd shim for running Slight workloads.
+"""
 
 [dependencies]
 chrono = "~0.4"

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-slight-v1"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -3,6 +3,12 @@ name = "containerd-shim-spin-v1"
 version = "0.4.0"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
+repository = 'https://github.com/deislabs/containerd-wasm-shims'
+license = "Apache-2.0"
+homepage = 'https://github.com/deislabs/containerd-wasm-shims'
+description = """
+Containerd shim for running Spin workloads.
+"""
 
 [dependencies]
 chrono = "~0.4"
@@ -26,4 +32,5 @@ url = "2.2.2"
 reqwest = { version = "0.11", features = ["stream"] }
 anyhow = "1.0"
 async-trait = "0.1"
+
 [workspace]

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-spin-v1"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 


### PR DESCRIPTION
@devigned Do we want to follow the runtimeclass and shim binary versioning scheme described in https://github.com/deislabs/containerd-wasm-shims/pull/16?