### PR TITLE
fix path for release artifacts in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build-slight:
 
 .PHONY: install
 install: build-spin build-slight
-	sudo $(INSTALL) target/release/containerd-shim-*-v1 $(PREFIX)/bin
+	sudo $(INSTALL) containerd-shim-*/target/release/containerd-shim-*-v1 $(PREFIX)/bin
 
 .PHONY: update-deps
 update-deps:


### PR DESCRIPTION
- Release artifacts are in sub project directories. When `make install` is run, the artifacts are not found and the copy will fail. This corrects that.