### PR TITLE
Chore: Update to use crates.io published runwasi

### DIFF
--- a/containerd-shim-slight-v1/Cargo.lock
+++ b/containerd-shim-slight-v1/Cargo.lock
@@ -1750,19 +1750,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -1838,7 +1825,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
 dependencies = [
- "env_logger 0.10.0",
+ "env_logger",
  "log",
 ]
 
@@ -4046,17 +4033,17 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "slight"
-version = "0.3.1"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+version = "0.3.2"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "as-any",
  "clap 4.1.6",
- "env_logger 0.9.3",
  "flate2",
  "log",
  "reqwest",
  "slight-common",
+ "slight-core",
  "slight-distributed-locking",
  "slight-http-client",
  "slight-http-server",
@@ -4065,7 +4052,6 @@ dependencies = [
  "slight-runtime",
  "slight-runtime-configs",
  "slight-sql",
- "spiderlightning",
  "tar",
  "tokio",
  "toml",
@@ -4077,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "slight-common"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "as-any",
@@ -4087,9 +4073,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "slight-core"
+version = "0.3.2"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
+dependencies = [
+ "anyhow",
+ "clap 4.1.6",
+ "rand 0.8.5",
+ "semver 1.0.16",
+ "serde",
+ "short-crypt",
+ "toml",
+]
+
+[[package]]
 name = "slight-distributed-locking"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "slight-http-api"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "slight-http-client"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "slight-http-server"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "slight-keyvalue"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4177,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "slight-messaging"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4201,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "slight-runtime"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "as-any",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "slight-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4230,7 +4230,7 @@ dependencies = [
  "regex",
  "short-crypt",
  "slight-common",
- "spiderlightning",
+ "slight-core",
  "toml",
  "tracing",
  "wit-bindgen-wasmtime 0.2.0 (git+https://github.com/bytecodealliance/wit-bindgen?tag=v0.2.0)",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "slight-sql"
 version = "0.1.0"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
+source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.2#5ec5324f513265e651f7bcf962a2edddedc75b22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4279,18 +4279,6 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spiderlightning"
-version = "0.3.1"
-source = "git+https://github.com/deislabs/spiderlightning?tag=v0.3.1#061d7b5c073a1f3b1b016509199ff4111c63ad0f"
-dependencies = [
- "anyhow",
- "rand 0.8.5",
- "serde",
- "short-crypt",
- "toml",
 ]
 
 [[package]]

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -14,7 +14,7 @@ Containerd shim for running Slight workloads.
 chrono = "~0.4"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 containerd-shim = "~0.3"
-containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", branch = "main" }
+containerd-shim-wasm = "0.1.1"
 log = "~0.4"
 tokio = { version = "1", features = [ "full" ] }
 tokio-util = { version = "0.6.10", features = [ "codec" ]}

--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -658,8 +658,9 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.1.0"
-source = "git+https://github.com/containerd/runwasi?branch=main#5037950bee1e8a616b0dd1a85daef4757a976e14"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616df9e7d24526784140455fe593cecd168d04bc089c478ec3ab293a0ac39aa0"
 dependencies = [
  "anyhow",
  "caps",
@@ -675,7 +676,6 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_json",
- "thirdparty",
  "thiserror",
  "ttrpc",
 ]
@@ -4021,15 +4021,6 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
-name = "thirdparty"
-version = "0.1.0"
-source = "git+https://github.com/containerd/runwasi?branch=main#5037950bee1e8a616b0dd1a85daef4757a976e14"
-dependencies = [
- "nix 0.26.2",
- "oci-spec 0.6.0",
-]
 
 [[package]]
 name = "thiserror"

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -14,7 +14,7 @@ Containerd shim for running Spin workloads.
 chrono = "~0.4"
 clap = { version = "3.1.15", features = ["derive", "env"] }
 containerd-shim = "~0.3"
-containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", branch = "main" }
+containerd-shim-wasm = "0.1.1"
 log = "~0.4"
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v0.9.0" }
 spin-app = { git = "https://github.com/fermyon/spin", tag = "v0.9.0" }


### PR DESCRIPTION
Since runwasi v0.1.1 has been published to crates.io, this PR updates the runwasi dep to it. 