### PR TITLE
feat: add dockerignore to reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.tmp
+target
+*/target*
+test
+images
+.dockerignore
+.gitignore


### PR DESCRIPTION
The docker build context for the slight shim, if including `target`, is often ~2GB in size. This slows down local development process. This PR adds a `.dockerignore` file to ignore target.