### PR TITLE
chore: bump spin to wasmtime 8.0.1

### DIFF
--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -690,10 +690,10 @@ dependencies = [
  "serde_json",
  "spin-app",
  "spin-core",
- "spin-http",
  "spin-loader",
  "spin-manifest",
  "spin-trigger",
+ "spin-trigger-http",
  "tokio",
  "tokio-util 0.7.7",
  "url",
@@ -2879,7 +2879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.26.2",
+ "nix 0.22.3",
 ]
 
 [[package]]
@@ -3219,7 +3219,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3381,6 +3381,15 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3916,6 +3925,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-trigger-http"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 3.2.23",
+ "futures",
+ "futures-util",
+ "http",
+ "hyper",
+ "indexmap",
+ "percent-encoding",
+ "rustls-pemfile 0.3.0",
+ "serde",
+ "serde_json",
+ "spin-app",
+ "spin-core",
+ "spin-http",
+ "spin-trigger",
+ "tls-listener",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "wasi-common 8.0.1",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wit-bindgen-wasmtime",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4161,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-listener"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8a215badde081a06ee0a7fbc9c9f0d580c022fbdc547065f62103aef71e178"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+]
 
 [[package]]
 name = "tokio"
@@ -4337,7 +4391,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "outbound-http"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "http",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "outbound-mysql"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "outbound-pg"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "outbound-redis"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "redis",
@@ -3733,7 +3733,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "spin-app"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "spin-config"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "spin-core"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "spin-http"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "http",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-redis"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "redis",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "spin-loader"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "spin-manifest"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "indexmap",
  "serde",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "spin-trigger"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "spin-trigger-http"
 version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -760,20 +760,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb658ef043a07ea4086c65f2e3d770b5dc60b8787a9ef54cf06d792cf613d82"
+checksum = "1277fbfa94bc82c8ec4af2ded3e639d49ca5f7f3c7eeab2c66accd135ece4e70"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36618d7ab9ad5da72935623292d364b5482ef42141e0145c0090bfc7f6b8dca"
+checksum = "c6e8c31ad3b2270e9aeec38723888fe1b0ace3bea2b06b3f749ccf46661d3220"
 dependencies = [
- "arrayvec",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -781,7 +780,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "log",
  "regalloc2",
  "smallvec",
@@ -790,33 +789,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7cab168dac35a2fc53a3591ee36d145d7fc2ebbdb5c70f1f9e35764157af5a"
+checksum = "c8ac5ac30d62b2d66f12651f6b606dbdfd9c2cfd0908de6b387560a277c5c9da"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcbdd64e35dfb910ff709e5b2d5e1348f626837685673726d985a620b9d8de5"
+checksum = "dd82b8b376247834b59ed9bdc0ddeb50f517452827d4a11bccf5937b213748b8"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e39cfc857e7e539aa623e03bb6bec11f54aef3dfdef41adcfa7b594af3b54"
+checksum = "40099d38061b37e505e63f89bab52199037a72b931ad4868d9089ff7268660b0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d28039844e3f7817e5a10cbb3d9adbc7188ee9cc4ba43536f304219fcfc077"
+checksum = "64a25d9d0a0ae3079c463c34115ec59507b4707175454f0eee0891e83e30e82d"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -826,15 +825,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4183c68346d657c40ea06273cc0e9c3fe25f4e51e6decf534c079f34041c43c0"
+checksum = "80de6a7d0486e4acbd5f9f87ec49912bf4c8fb6aea00087b989685460d4469ba"
 
 [[package]]
 name = "cranelift-native"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dbf72319054ff725a26c579b4070187928ca38e55111b964723bdbacbb1993e"
+checksum = "bb6b03e0e03801c4b3fd8ce0758a94750c07a44e7944cc0ffbf0d3f2e7c79b00"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -843,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.92.1"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3632b478ca00dfad77dbef3ce284f1199930519ab744827726a8e386a6db3f5"
+checksum = "ff3220489a3d928ad91e59dd7aeaa8b3de18afb554a6211213673a71c90737ac"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -853,7 +852,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.102.0",
  "wasmtime-types",
 ]
 
@@ -1584,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -1635,15 +1634,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1662,11 +1652,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1715,6 +1705,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "host"
+version = "0.0.0"
+source = "git+https://github.com/fermyon/spin-componentize?rev=51c3fade751c4e364142719e42130943fd8b0a76#51c3fade751c4e364142719e42130943fd8b0a76"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-rand",
+ "cap-std",
+ "clap 4.1.11",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasi-cap-std-sync 0.0.0",
+ "wasi-common 0.0.0",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2088,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2468,12 +2476,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "crc32fast",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "indexmap",
  "memchr",
 ]
@@ -2602,8 +2610,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "http",
@@ -2617,8 +2625,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "mysql_async",
@@ -2632,8 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "native-tls",
@@ -2647,8 +2655,8 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "redis",
@@ -3148,9 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
 dependencies = [
  "fxhash",
  "log",
@@ -3211,7 +3219,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile 1.0.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3271,16 +3279,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.0.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "smallvec",
 ]
 
@@ -3374,15 +3381,6 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]
@@ -3725,8 +3723,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3738,9 +3736,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-componentize"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/spin-componentize?rev=51c3fade751c4e364142719e42130943fd8b0a76#51c3fade751c4e364142719e42130943fd8b0a76"
+dependencies = [
+ "anyhow",
+ "wasm-encoder 0.26.0",
+ "wasmparser 0.104.0",
+ "wit-component",
+]
+
+[[package]]
 name = "spin-config"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3757,50 +3766,41 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cap-std",
  "crossbeam-channel",
+ "host",
+ "system-interface",
  "tracing",
- "wasi-cap-std-sync",
- "wasi-common",
+ "wasi-cap-std-sync 0.0.0",
+ "wasi-common 0.0.0",
+ "wasi-common 8.0.1",
  "wasmtime",
  "wasmtime-wasi",
 ]
 
 [[package]]
 name = "spin-http"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
- "async-trait",
- "clap 3.2.23",
- "futures",
- "futures-util",
  "http",
  "hyper",
  "indexmap",
  "percent-encoding",
- "rustls-pemfile 0.3.0",
  "serde",
- "serde_json",
- "spin-app",
- "spin-core",
- "spin-trigger",
- "tls-listener",
- "tokio",
- "tokio-rustls",
  "tracing",
- "wit-bindgen-wasmtime",
 ]
 
 [[package]]
 name = "spin-key-value"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
@@ -3812,22 +3812,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-redis"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
+dependencies = [
+ "anyhow",
+ "redis",
+ "spin-core",
+ "spin-key-value",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "once_cell",
  "rusqlite",
+ "spin-core",
  "spin-key-value",
  "tokio",
- "wit-bindgen-wasmtime",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3859,8 +3872,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "indexmap",
  "serde",
@@ -3870,8 +3883,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.0.0"
-source = "git+https://github.com/fermyon/spin?tag=v1.0.0#df99be238267b498451993d47b7e42e17da95c09"
+version = "1.2.0-pre0"
+source = "git+https://github.com/fermyon/spin?rev=e040522a6d1b3250d97a41bc824f7d1c467d8309#e040522a6d1b3250d97a41bc824f7d1c467d8309"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3887,9 +3900,11 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-app",
+ "spin-componentize",
  "spin-config",
  "spin-core",
  "spin-key-value",
+ "spin-key-value-redis",
  "spin-key-value-sqlite",
  "spin-loader",
  "spin-manifest",
@@ -4106,20 +4121,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tls-listener"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8a215badde081a06ee0a7fbc9c9f0d580c022fbdc547065f62103aef71e178"
-dependencies = [
- "futures-util",
- "hyper",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tokio-rustls",
-]
 
 [[package]]
 name = "tokio"
@@ -4526,9 +4527,33 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "5.0.1"
+version = "0.0.0"
+source = "git+https://github.com/fermyon/spin-componentize?rev=51c3fade751c4e364142719e42130943fd8b0a76#51c3fade751c4e364142719e42130943fd8b0a76"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "is-terminal",
+ "once_cell",
+ "rustix",
+ "system-interface",
+ "tracing",
+ "wasi-common 0.0.0",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "wasi-cap-std-sync"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91109b23018beb7c9ecf090e3e4a81138a662c04a1d08ce46804ffddc27d49a5"
+checksum = "612510e6c7b6681f7d29ce70ef26e18349c26acd39b7d89f1727d90b7f58b20e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4544,34 +4569,55 @@ dependencies = [
  "rustix",
  "system-interface",
  "tracing",
- "wasi-common",
- "windows-sys 0.42.0",
+ "wasi-common 8.0.1",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasi-common"
-version = "5.0.1"
+version = "0.0.0"
+source = "git+https://github.com/fermyon/spin-componentize?rev=51c3fade751c4e364142719e42130943fd8b0a76#51c3fade751c4e364142719e42130943fd8b0a76"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 1.3.2",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "io-extras",
+ "ipnet",
+ "rustix",
+ "system-interface",
+ "thiserror",
+ "tracing",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "wasi-common"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46604ebe82881f99d88095c171eb84ae078c6b2a13f8f8f20ec00da60c8f6faf"
+checksum = "008136464e438c5049a614b6ea1bae9f6c4d354ce9ee2b4d9a1ac6e73f31aafc"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
  "cap-rand",
  "cap-std",
  "io-extras",
+ "log",
  "rustix",
  "thiserror",
  "tracing",
  "wasmtime",
  "wiggle",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasi-tokio"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3d3c89e2dec9644b3ba06e09f29f93aa5150bb33df86ee98b57ec91331f945"
+checksum = "c24672bbdac9b6ccd6f19e846bef945f63729abcea4c1c3f0ba725faad055e9d"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4579,8 +4625,8 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "tokio",
- "wasi-cap-std-sync",
- "wasi-common",
+ "wasi-cap-std-sync 8.0.1",
+ "wasi-common 8.0.1",
  "wiggle",
 ]
 
@@ -4660,6 +4706,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05d0b6fcd0aeb98adf16e7975331b3c17222aa815148f5b976370ce589d80ef"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbdef99fafff010c57fabb7bc703f0903ec16fcee49207a22dcc4f78ea44562f"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "wasm-encoder 0.26.0",
+ "wasmparser 0.104.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4674,24 +4742,45 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.96.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adde01ade41ab9a5d10ec8ed0bb954238cf8625b5cd5a13093d6de2ad9c2be1a"
+checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
 dependencies = [
  "indexmap",
  "url",
 ]
 
 [[package]]
-name = "wasmtime"
-version = "5.0.1"
+name = "wasmparser"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ffcc607adc9da024e87ca814592d4bc67f5c5b58e488f5608d5734a1ebc23e"
+checksum = "6a396af81a7c56ad976131d6a35e4b693b78a1ea0357843bd436b4577e254a7d"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731da2505d5437cd5d6feb09457835f76186be13be7677fe00781ae99d5bbe8a"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.104.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f907fdead3153cb9bfb7a93bbd5b62629472dc06dee83605358c64c52ed3dda9"
 dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
  "cfg-if 1.0.0",
+ "encoding_rs",
  "indexmap",
  "libc",
  "log",
@@ -4702,35 +4791,36 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.102.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
+ "wasmtime-component-util",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-runtime",
  "wat",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb5dc4d79cd7b2453c395f64e9013d2ad90bd083be556d5565cb224ebe8d57"
+checksum = "d3b9daa7c14cd4fa3edbf69de994408d5f4b7b0959ac13fa69d465f6597f810d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b1611b04c29f2c4a434f109f6143a0719cb8b558370371d1bae7643aa173af"
+checksum = "c86437fa68626fe896e5afc69234bb2b5894949083586535f200385adfd71213"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -4739,35 +4829,36 @@ dependencies = [
  "serde",
  "sha2 0.10.6",
  "toml",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5c3d25a7d531582fbaa75ce6a86dddc8211c783cb247af053075a0fcc9d3d7"
+checksum = "267096ed7cc93b4ab15d3daa4f195e04dbb7e71c7e5c6457ae7d52e9dd9c3607"
 dependencies = [
+ "anyhow",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.3.1",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0e0e3a1310cdde7db4e8634bda696ca4f80c429fbd727fa827be5f9cb35d21"
+checksum = "74e02ca7a4a3c69d72b88f26f0192e333958df6892415ac9ab84dcc42c9000c2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66a3f2167a7436910c6cbac2408a7b599688d7114cb8821cb10879dae451759"
+checksum = "b1cefde0cce8cb700b1b21b6298a3837dba46521affd7b8c38a9ee2c869eee04"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4780,15 +4871,31 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.102.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd041e382ef5aea1b9fc78442394f1a4f6d676ce457e7076ca4cb3f397882f8b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-native",
+ "gimli",
+ "object",
+ "target-lexicon",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9350c919553cddf14f78f9452119c8004d7ef6bfebb79a41a21819ed0c5604d8"
+checksum = "a990198cee4197423045235bf89d3359e69bd2ea031005f4c2d901125955c949"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4799,28 +4906,31 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasm-encoder 0.25.0",
+ "wasmparser 0.102.0",
+ "wasmprinter",
+ "wasmtime-component-util",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7459893ae6d67f9b35b04f44df8dfc037ea7f3071d710b9f7866b79cb2c482ae"
+checksum = "7ab182d5ab6273a133ab88db94d8ca86dc3e57e43d70baaa4d98f94ddbd7d10a"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "rustix",
  "wasmtime-asm-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ba5779ea786386432b94c9fc9ad5597346c319e8239db0d98d5be5cc109a7e"
+checksum = "0de48df552cfca1c9b750002d3e07b45772dd033b0b206d5c0968496abf31244"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4838,14 +4948,14 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9841a44c82c74101c10ad4f215392761a2523b3c6c838597962bdb6de75fdb3"
+checksum = "6e0554b84c15a27d76281d06838aed94e13a77d7bf604bbbaf548aa20eb93846"
 dependencies = [
  "object",
  "once_cell",
@@ -4854,30 +4964,31 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4356c2493002da3b111d470c2ecea65a3017009afce8adc46eaa5758739891"
+checksum = "aecae978b13f7f67efb23bd827373ace4578f2137ec110bbf6a4a7cde4121bbd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26efea7a790fcf430e663ba2519f0ab6eb8980adf8b0c58c62b727da77c2ec"
+checksum = "658cf6f325232b6760e202e5255d823da5e348fdea827eff0a2a22319000b441"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
+ "encoding_rs",
  "indexmap",
  "libc",
  "log",
  "mach",
  "memfd",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "paste",
  "rand 0.8.5",
  "rustix",
@@ -4885,30 +4996,31 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e1e4f66a2b9a114f9def450ab9971828c968db6ea6fccd613724b771fa4913"
+checksum = "a4f6fffd2a1011887d57f07654dd112791e872e3ff4a2e626aee8059ee17f06f"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.102.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa31e718a1f7294fc44a9eef13abf6ef32fd0574d9d7b365fee9ca24730a822"
+checksum = "4a3b5cb7606625ec229f0e33394a1637b34a58ad438526eba859b5fdb422ac1e"
 dependencies = [
  "anyhow",
- "wasi-cap-std-sync",
- "wasi-common",
+ "libc",
+ "wasi-cap-std-sync 8.0.1",
+ "wasi-common 8.0.1",
  "wasi-tokio",
  "wasmtime",
  "wiggle",
@@ -4916,13 +5028,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97566c073045a48b745f3559689295140f00fff7f2799efe8c89cc7e70ae007"
+checksum = "983db9cc294d1adaa892a53ff6a0dc6605fc0ab1a4da5d8a2d2d4bde871ff7dd"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "wit-parser 0.3.1",
+ "wit-parser 0.6.4",
 ]
 
 [[package]]
@@ -4943,7 +5055,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.25.0",
 ]
 
 [[package]]
@@ -4986,9 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edae96a8cef2aaf1d2ce42a41814ee1a0fb55c5171de6b6166bd2d6fa2f5b7b"
+checksum = "6b16a7462893c46c6d3dd2a1f99925953bdbb921080606e1a4c9344864492fa4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5001,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3219ec3173dba79319622add6af2d4f71ec6fe9e446a119f39b1e8f76534ad2b"
+checksum = "489499e186ab24c8ac6d89e9934c54ced6f19bd473730e6a74f533bd67ecd905"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -5016,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "5.0.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fd7c907d4640faf42369832a583304476aa0178cb7481c5772c0495effa8b2"
+checksum = "e9142e7fce24a4344c85a43c8b719ef434fc6155223bade553e186cb4183b6cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5170,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-core"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "anyhow",
  "wit-parser 0.2.0",
@@ -5179,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "heck 0.3.3",
  "wit-bindgen-gen-core",
@@ -5188,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-wasmtime"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "heck 0.3.3",
  "wit-bindgen-gen-core",
@@ -5198,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-wasmtime"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5211,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-wasmtime-impl"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -5220,9 +5332,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e291ff83cb9c8e59963cc6922bdda77ed8f5517d6835f0c98070c4e7f1ae4996"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "indexmap",
+ "log",
+ "url",
+ "wasm-encoder 0.26.0",
+ "wasm-metadata",
+ "wasmparser 0.104.0",
+ "wit-parser 0.7.1",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.2.0"
-source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=a39003fadce6c7a8654e3e044fc39fc80d81ec7b#a39003fadce6c7a8654e3e044fc39fc80d81ec7b"
+source = "git+https://github.com/fermyon/wit-bindgen-backport?rev=ba1636af0338623b54db84e2224be9a124e231f6#ba1636af0338623b54db84e2224be9a124e231f6"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -5233,15 +5362,32 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.3.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703eb1d2f89ff2c52d50f7ff002735e423cea75f0a5dc5c8a4626c4c47cd9ca6"
+checksum = "f887c3da527a51b321076ebe6a7513026a4757b6d4d144259946552d6fc728b3"
 dependencies = [
  "anyhow",
  "id-arena",
  "indexmap",
+ "log",
  "pulldown-cmark",
  "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca2581061573ef6d1754983d7a9b3ed5871ef859d52708ea9a0f5af32919172"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "pulldown-cmark",
+ "unicode-xid",
+ "url",
 ]
 
 [[package]]

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -16,15 +16,15 @@ clap = { version = "4.1.9", features = ["derive", "env"] }
 containerd-shim = "~0.3"
 containerd-shim-wasm = "0.1.1"
 log = "~0.4"
-spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
-spin-app = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
-spin-core = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
-spin-http = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
-spin-loader = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
-spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v1.0.0" }
+spin-trigger = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-app = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-core = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-http = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-loader = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-manifest = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+wasmtime = "8.0.1"
 tokio = { version = "1", features = ["rt"] }
 tokio-util = { version = "0.7.7", features = ["codec"] }
-wasmtime = "5.0"
 openssl = { version = "*", features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.82"

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -19,7 +19,7 @@ log = "~0.4"
 spin-trigger = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
 spin-app = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
 spin-core = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-http = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
 spin-loader = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
 spin-manifest = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
 wasmtime = "8.0.1"

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -16,12 +16,12 @@ clap = { version = "4.1.9", features = ["derive", "env"] }
 containerd-shim = "~0.3"
 containerd-shim-wasm = "0.1.1"
 log = "~0.4"
-spin-trigger = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-app = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-core = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-loader = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
-spin-manifest = { git = "https://github.com/fermyon/spin", rev = "e040522a6d1b3250d97a41bc824f7d1c467d8309" }
+spin-trigger = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-app = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-core = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-loader = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-manifest = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
 wasmtime = "8.0.1"
 tokio = { version = "1", features = ["rt"] }
 tokio-util = { version = "0.7.7", features = ["codec"] }

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -18,10 +18,9 @@ use containerd_shim_wasm::sandbox::{
 };
 use log::info;
 use reqwest::Url;
-use spin_http::HttpTrigger;
 use spin_manifest::Application;
-use spin_trigger::runtime_config::RuntimeConfig;
-use spin_trigger::{loader, TriggerExecutor, TriggerExecutorBuilder};
+use spin_trigger::{loader, RuntimeConfig, TriggerExecutor, TriggerExecutorBuilder};
+use spin_trigger_http::HttpTrigger;
 use tokio::runtime::Runtime;
 use wasmtime::OptLevel;
 
@@ -184,7 +183,7 @@ impl Instance for Wasi {
                     });
 
                     info!(" >>> running spin trigger");
-                    let f = http_trigger.run(spin_http::CliArgs {
+                    let f = http_trigger.run(spin_trigger_http::CliArgs {
                         address: parse_addr(SPIN_ADDR).unwrap(),
                         tls_cert: None,
                         tls_key: None,

--- a/containerd-shim-spin-v1/src/podio.rs
+++ b/containerd-shim-spin-v1/src/podio.rs
@@ -5,8 +5,7 @@ use std::{
 
 use spin_app::{App, AppComponent};
 use spin_core::StoreBuilder;
-use spin_trigger::runtime_config::RuntimeConfig;
-use spin_trigger::TriggerHooks;
+use spin_trigger::{RuntimeConfig, TriggerHooks};
 
 pub struct PodioLoggingTriggerHooks {
     stdout_pipe: Option<File>,


### PR DESCRIPTION
This PR is pending https://github.com/fermyon/spin/pull/1433 and as soon as spin's PR to bump to wasmtime 8.0.1 is merged in, it's ready to review. 