### PR TITLE
enable all capability linkage

### DIFF
--- a/containerd-shim-slight-v1/src/main.rs
+++ b/containerd-shim-slight-v1/src/main.rs
@@ -117,7 +117,7 @@ impl Instance for Wasi {
                             stdout_path: Some(PathBuf::from(pod_stdout)),
                             stderr_path: Some(PathBuf::from(pod_stderr)),
                         }),
-                        link_all_capabilities: false,
+                        link_all_capabilities: true,
                     };
                     let f = handle_run(args);
 


### PR DESCRIPTION
For JS guest applications (made possible in slight v0.5.0), all capability linkage must be enabled. This is because all capabilities are baked into the SlightJS engine, and so it expects them to be available in Wasmtime. If not, we get this error:
![image](https://user-images.githubusercontent.com/39843321/236267070-5af56e1e-1b0c-49e0-ae94-03356909081d.png)

This does not impact applications that don't require all capabilities linked, as those are still added to our capability store later on. All this those is link them in Wasmtime.