### PR TITLE
chore: bump spin 1.2.0

### DIFF
--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -2610,14 +2610,15 @@ dependencies = [
 
 [[package]]
 name = "outbound-http"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "http",
  "reqwest",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tracing",
  "url",
  "wit-bindgen-wasmtime",
@@ -2625,13 +2626,14 @@ dependencies = [
 
 [[package]]
 name = "outbound-mysql"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "mysql_async",
  "mysql_common",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "url",
@@ -2640,13 +2642,14 @@ dependencies = [
 
 [[package]]
 name = "outbound-pg"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "native-tls",
  "postgres-native-tls",
  "spin-core",
+ "spin-world",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -2655,12 +2658,13 @@ dependencies = [
 
 [[package]]
 name = "outbound-redis"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "redis",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -3732,8 +3736,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin-app"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3742,6 +3746,16 @@ dependencies = [
  "serde_json",
  "spin-core",
  "thiserror",
+]
+
+[[package]]
+name = "spin-common"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
+dependencies = [
+ "anyhow",
+ "sha2 0.10.6",
+ "tokio",
 ]
 
 [[package]]
@@ -3757,8 +3771,8 @@ dependencies = [
 
 [[package]]
 name = "spin-config"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3767,6 +3781,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-core",
+ "spin-world",
  "thiserror",
  "tokio",
  "vaultrs",
@@ -3775,8 +3790,8 @@ dependencies = [
 
 [[package]]
 name = "spin-core"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3794,8 +3809,8 @@ dependencies = [
 
 [[package]]
 name = "spin-http"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "http",
@@ -3808,13 +3823,14 @@ dependencies = [
 
 [[package]]
 name = "spin-key-value"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "lru 0.9.0",
  "spin-app",
  "spin-core",
+ "spin-world",
  "tokio",
  "tracing",
  "wit-bindgen-wasmtime",
@@ -3823,12 +3839,13 @@ dependencies = [
 [[package]]
 name = "spin-key-value-redis"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "redis",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
  "url",
 ]
@@ -3836,20 +3853,21 @@ dependencies = [
 [[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "once_cell",
  "rusqlite",
  "spin-core",
  "spin-key-value",
+ "spin-world",
  "tokio",
 ]
 
 [[package]]
 name = "spin-loader"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3869,7 +3887,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.6",
+ "spin-common",
  "spin-manifest",
  "tempfile",
  "tokio",
@@ -3881,8 +3899,8 @@ dependencies = [
 
 [[package]]
 name = "spin-manifest"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "indexmap",
  "serde",
@@ -3892,8 +3910,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3901,6 +3919,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "futures",
+ "indexmap",
  "outbound-http",
  "outbound-mysql",
  "outbound-pg",
@@ -3909,6 +3928,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-app",
+ "spin-common",
  "spin-componentize",
  "spin-config",
  "spin-core",
@@ -3926,8 +3946,8 @@ dependencies = [
 
 [[package]]
 name = "spin-trigger-http"
-version = "1.2.0-pre0"
-source = "git+https://github.com/fermyon/spin?rev=2f50f3e5db61bc68339882f903a283e8bc82185c#2f50f3e5db61bc68339882f903a283e8bc82185c"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3945,6 +3965,7 @@ dependencies = [
  "spin-core",
  "spin-http",
  "spin-trigger",
+ "spin-world",
  "tls-listener",
  "tokio",
  "tokio-rustls",
@@ -3953,6 +3974,14 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-wasmtime",
+]
+
+[[package]]
+name = "spin-world"
+version = "1.2.0"
+source = "git+https://github.com/fermyon/spin?tag=v1.2.0#c4fbd08eb75ce9b2729bf7c450520076e692c6af"
+dependencies = [
+ "wasmtime",
 ]
 
 [[package]]

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -16,12 +16,12 @@ clap = { version = "4.1.9", features = ["derive", "env"] }
 containerd-shim = "~0.3"
 containerd-shim-wasm = "0.1.1"
 log = "~0.4"
-spin-trigger = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
-spin-app = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
-spin-core = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
-spin-trigger-http = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
-spin-loader = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
-spin-manifest = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
+spin-app = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
+spin-core = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
+spin-trigger-http = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
+spin-loader = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
+spin-manifest = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
 wasmtime = "8.0.1"
 tokio = { version = "1", features = ["rt"] }
 tokio-util = { version = "0.7.7", features = ["codec"] }

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -94,7 +94,8 @@ impl Wasi {
             stdin_pipe_path,
         );
         builder.hooks(logging_hooks);
-        let executor = builder.build(locked_url, runtime_config).await?;
+        let init_data = Default::default();
+        let executor = builder.build(locked_url, runtime_config, init_data).await?;
         Ok(executor)
     }
 }

--- a/images/slight/Dockerfile
+++ b/images/slight/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} rust:1.64 AS build
+FROM --platform=${BUILDPLATFORM} rust:1.69 AS build
 WORKDIR /opt/build
 COPY . .
 RUN rustup target add wasm32-wasi && cargo build --target wasm32-wasi --release

--- a/images/spin-outbound-redis/Cargo.toml
+++ b/images/spin-outbound-redis/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 anyhow = "1"
 bytes = "1"
 http = "0.2"
-spin-sdk = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 
 [workspace]

--- a/images/spin/Cargo.toml
+++ b/images/spin/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 anyhow = "1"
 bytes = "1"
 http = "0.2" 
-spin-sdk = { git = "https://github.com/fermyon/spin", rev = "2f50f3e5db61bc68339882f903a283e8bc82185c" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v1.2.0" }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 
 [workspace]

--- a/images/spin/Dockerfile
+++ b/images/spin/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} rust:1.67 AS build
+FROM --platform=${BUILDPLATFORM} rust:1.69 AS build
 WORKDIR /opt/build
 COPY . .
 RUN rustup target add wasm32-wasi && cargo build --target wasm32-wasi --release


### PR DESCRIPTION
This bumps spin to version 1.2.0. 

It looks like spin adds a third argument to `builder.build` which seems like it's an argument for testing purposes only. I will send an issue to ask if it can be removed. 