### PR TITLE
feat: bump containerd-shim-wws main wws dependency to v1.2.0

### DIFF
--- a/containerd-shim-wws-v1/Cargo.lock
+++ b/containerd-shim-wws-v1/Cargo.lock
@@ -414,17 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wws-v1"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "containerd-shim",
@@ -2331,12 +2320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,17 +3481,14 @@ dependencies = [
 [[package]]
 name = "wax"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c7a3bac6110ac062b7b422a442b7ee23e07209e2784a036654cab1e71bbafc"
+source = "git+https://github.com/olson-sean-k/wax.git?rev=6d66a10#6d66a10f5a00cdb7a8a0bf1147fa406bb4a433e2"
 dependencies = [
- "bstr",
  "const_format",
  "itertools",
  "nom",
  "nom-supreme",
  "pori",
  "regex",
- "smallvec",
  "thiserror",
  "walkdir",
 ]
@@ -3735,8 +3715,8 @@ dependencies = [
 
 [[package]]
 name = "wws-config"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "anyhow",
  "serde",
@@ -3747,8 +3727,8 @@ dependencies = [
 
 [[package]]
 name = "wws-data-kv"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "anyhow",
  "serde",
@@ -3757,8 +3737,8 @@ dependencies = [
 
 [[package]]
 name = "wws-router"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "lazy_static",
  "regex",
@@ -3771,8 +3751,8 @@ dependencies = [
 
 [[package]]
 name = "wws-runtimes"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "anyhow",
  "serde",
@@ -3785,8 +3765,8 @@ dependencies = [
 
 [[package]]
 name = "wws-runtimes-manager"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3800,8 +3780,8 @@ dependencies = [
 
 [[package]]
 name = "wws-server"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -3813,8 +3793,8 @@ dependencies = [
 
 [[package]]
 name = "wws-store"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3822,8 +3802,8 @@ dependencies = [
 
 [[package]]
 name = "wws-worker"
-version = "1.1.1"
-source = "git+https://github.com/vmware-labs/wasm-workers-server?rev=5207684#52076845fc079e4677b1a8dc90e93ef2916d8428"
+version = "1.2.0"
+source = "git+https://github.com/vmware-labs/wasm-workers-server?tag=v1.2.0#9f9552d72bf94953e7a6862ebb972bd048db13c7"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/containerd-shim-wws-v1/Cargo.toml
+++ b/containerd-shim-wws-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wws-v1"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Wasm Labs team <wasmlabs@vmware.com>"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'
@@ -15,9 +15,9 @@ Containerd shim for running Wasm Workers Server workloads.
 [dependencies]
 containerd-shim = "~0.3"
 containerd-shim-wasm = "0.1.1"
-wws-config = { git = "https://github.com/vmware-labs/wasm-workers-server", rev = "5207684" }
-wws-server = { git = "https://github.com/vmware-labs/wasm-workers-server", rev = "5207684" }
-wws-router = { git = "https://github.com/vmware-labs/wasm-workers-server", rev = "5207684" }
+wws-config = { git = "https://github.com/vmware-labs/wasm-workers-server", tag = "v1.2.0" }
+wws-server = { git = "https://github.com/vmware-labs/wasm-workers-server", tag = "v1.2.0" }
+wws-router = { git = "https://github.com/vmware-labs/wasm-workers-server", tag = "v1.2.0" }
 log = "~0.4"
 tokio = { version = "1", features = [ "full" ] }
 tokio-util = { version = "0.6.10", features = [ "codec" ]}

--- a/containerd-shim-wws-v1/src/main.rs
+++ b/containerd-shim-wws-v1/src/main.rs
@@ -135,7 +135,7 @@ impl Instance for Workers {
                         error!("[wws] You can install the missing runtimes with: wws runtimes install");
                     }
 
-                    let routes = Routes::new(&path, "", &config);
+                    let routes = Routes::new(&path, "", Vec::new(), &config);
 
                     // Final server
                     let f = serve(&path, routes, WWS_ADDR, WWS_PORT, Some(stderr_path)).await.unwrap();


### PR DESCRIPTION
Upgrade the containerd-shim-wws to the latest version of `wws`. We introduced a small change that requires to adapt a method call. This version also includes the configuration of the `stderr`, so we don't need to point to a specific commit anymore 😄 

**References:** 

* [Wasm Workers Server v.1.2.0 release](https://github.com/vmware-labs/wasm-workers-server/releases/tag/v1.2.0)