### PR TITLE
fix: wws release CI typo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
           tags: |
             ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:${{ env.RELEASE_VERSION }}
             ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:latest
-          context: images/slight
+          context: images/wws
           platforms: wasi/wasm
       - name: untar x86_64 musl artifacts into ./deployments/k3d/.tmp dir
         run: |

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -93,9 +93,15 @@ spec:
       runtimeClassName: wasmtime-wws
       containers:
         - name: wws-hello
-          imagePullPolicy: Never
           image: ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:v0.7.0
           command: ["/"]
+          resources: # limit the resources to 128Mi of memory and 100m of CPU
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Fixed a typo in the release pipeline that uses the wrong context for the wws image. It also deletes the NEVER pullpolicy from the workload YAML to be consistent with other services.