### PR TITLE
feat: simplify makefiles and CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            "containerd-shim-slight-v1 -> target"
-            "containerd-shim-spin-v1 -> target"
-            "containerd-shim-wws-v1 -> target"
+            "containerd-shim-*-v1 -> target"
       - name: "Install Rust Wasm targets"
         run: |
           make install-rust-targets
@@ -36,7 +34,7 @@ jobs:
           sudo apt-get install protobuf-compiler -y
       - name: build
         run: |
-          make build
+          VERBOSE=1 make build
       - name: lowercase the runner OS name
         shell: bash
         run: |
@@ -45,9 +43,9 @@ jobs:
       - name: package release assets
         run: |
           mkdir _dist
-          cp containerd-shim-slight-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
-          cp containerd-shim-spin-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
-          cp containerd-shim-wws-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
+          for shim in slight spin wws; do
+            cp containerd-shim-$shim-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
+          done
           cd _dist
           tar czf containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
       - name: upload shim artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,7 @@ jobs:
       - name: package release assets
         run: |
           mkdir _dist
-          for shim in slight spin wws; do
-            cp containerd-shim-$shim-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
-          done
+          cp containerd-shim-*-v1/target/${{ matrix.config.arch }}-unknown-linux-musl/release/containerd-shim-*-v1 _dist/
           cd _dist
           tar czf containerd-wasm-shims-v1-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz containerd-shim-*-v1
       - name: upload shim artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            "containerd-shim-slight-v1 -> target"
-            "containerd-shim-spin-v1 -> target"
-            "containerd-shim-wws-v1 -> target"
+            "containerd-shim-*-v1 -> target"
       - name: "Install Rust Wasm targets"
         run: |
           make install-rust-targets
@@ -36,9 +34,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            "containerd-shim-slight-v1 -> target"
-            "containerd-shim-spin-v1 -> target"
-            "containerd-shim-wws-v1 -> target"
+            "containerd-shim-*-v1 -> target"
       - name: "Install Rust Wasm targets"
         run: |
           make install-rust-targets

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,29 @@
+name: 'Build and push Docker images'
+on:
+  workflow_call:
+    inputs:
+      images:
+        required: true
+        type: string
+      platforms:
+        required: true
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ${{fromJson(github.event.inputs.images)}}
+    steps:
+    - name: build and push
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: |
+          ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:${{ env.RELEASE_VERSION }}
+          ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:latest
+        context: ${{ matrix.image.context }}
+        platforms: ${{ github.event.inputs.platforms }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,41 +53,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build and push Spin hello world
-        uses: docker/build-push-action@v3
+      - name: Build and push images
+        uses: ./.github/workflows/build_and_push.yaml
         with:
-          push: true
-          tags: |
-            ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:${{ env.RELEASE_VERSION }}
-            ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:latest
-          context: images/spin
-          platforms: wasi/wasm
-      - name: build and push Spin DotNet
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: |
-            ghcr.io/deislabs/containerd-wasm-shims/examples/spin-dotnet-hello:${{ env.RELEASE_VERSION }}
-            ghcr.io/deislabs/containerd-wasm-shims/examples/spin-dotnet-hello:latest
-          context: images/spin_dotnet
-          platforms: wasi/wasm
-      - name: build and push Slight hello world
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: |
-            ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:${{ env.RELEASE_VERSION }}
-            ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:latest
-          context: images/slight
-          platforms: wasi/wasm
-      - name: build and push Wasm Workers Server (wws) hello world (JS)
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: |
-            ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:${{ env.RELEASE_VERSION }}
-            ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:latest
-          context: images/wws
+          images: |
+            [{"imageName": "examples/spin-rust-hello", "context": "images/spin"},
+            {"imageName": "examples/spin-dotnet-hello", "context": "images/spin_dotnet"},
+            {"imageName": "examples/slight-rust-hello", "context": "images/slight"},
+            {"imageName": "examples/wws-js-hello", "context": "images/wws"},
+            {"imageName": "examples/spin-inbound-redis", "context": "images/spin-inbound-redis"},
+            {"imageName": "examples/spin-outbound-redis", "context": "images/spin-outbound-redis"}]
           platforms: wasi/wasm
       - name: untar x86_64 musl artifacts into ./deployments/k3d/.tmp dir
         run: |

--- a/deployments/k3d/Makefile
+++ b/deployments/k3d/Makefile
@@ -1,26 +1,21 @@
+SHIMS = spin slight wws
+
 IMAGE_NAME ?= k3swithshims
 CLUSTER_NAME ?= k3s-default
 PLATFORM ?= linux/amd64
 ARCH ?= x86_64
 TARGET ?= $(ARCH)-unknown-linux-musl
-TEST_IMG_NAME_SPIN ?= wasmtest_spin:latest
-TEST_IMG_NAME_SLIGHT ?= wasmtest_slight:latest
-TEST_IMG_NAME_WWS ?= wasmtest_wws:latest
+TEST_IMG_NAME_spin ?= wasmtest_spin:latest
+TEST_IMG_NAME_slight ?= wasmtest_slight:latest
+TEST_IMG_NAME_wws ?= wasmtest_wws:latest
 
-compile-musl-spin:
-	make build-spin-cross-$(TARGET) -C ../..
+compile-musl-%:
+	make build-$*-cross-$(TARGET) -C ../..
 
-compile-musl-slight:
-	make build-slight-cross-$(TARGET) -C ../..
-
-compile-musl-wws:
-	make build-wws-cross-$(TARGET) -C ../..
-
-move-musl-to-tmp: compile-musl-spin compile-musl-slight compile-musl-wws
+move-musl-to-tmp: $(addprefix compile-musl-,$(SHIMS))
 	mkdir -p ./.tmp
-	cp ../../containerd-shim-slight-v1/target/$(TARGET)/release/containerd-shim-*-v1 ./.tmp/
-	cp ../../containerd-shim-spin-v1/target/$(TARGET)/release/containerd-shim-*-v1 ./.tmp/
-	cp ../../containerd-shim-wws-v1/target/$(TARGET)/release/containerd-shim-*-v1 ./.tmp/
+	$(foreach shim,$(SHIMS),cp ../../containerd-shim-$(shim)-v1/target/$(TARGET)/release/containerd-shim-*-v1 ./.tmp/;)
+
 
 build-multi-k3d-image: move-musl-to-tmp
 	docker buildx build -t $(IMAGE_NAME) --platform linux/amd64,linux/arm64 .
@@ -32,23 +27,17 @@ create-k3d: build-dev-k3d-image
 	k3d cluster create $(CLUSTER_NAME) --image $(IMAGE_NAME) --api-port 6550 -p "8081:80@loadbalancer" --agents 1
 
 build-workload-images:
-	docker buildx build --platform=wasi/wasm --load -t $(TEST_IMG_NAME_SPIN) ../../images/spin
-	docker buildx build --platform=wasi/wasm --load -t $(TEST_IMG_NAME_SLIGHT) ../../images/slight
-	docker buildx build --platform=wasi/wasm --load -t $(TEST_IMG_NAME_WWS) ../../images/wws
+	$(foreach shim,$(SHIMS),docker buildx build --platform=wasi/wasm --load -t $(TEST_IMG_NAME_$(shim)) ../../images/$(shim);)
 
 load-workload-images: build-workload-images
-	k3d image load $(TEST_IMG_NAME_SPIN)
-	k3d image load $(TEST_IMG_NAME_SLIGHT)
-	k3d image load $(TEST_IMG_NAME_WWS)
+	$(foreach shim,$(SHIMS),k3d image load $(TEST_IMG_NAME_$(shim));)
 
 up: create-k3d load-workload-images
 	kubectl label nodes k3d-k3s-default-agent-0 spin-enabled=true slight-enabled=true wws-enabled=true
 	kubectl apply -f ./workload
 
 test:
-	curl localhost:8081/spin/hello
-	curl localhost:8081/slight/hello
-	curl localhost:8081/wws/hello
+	$(foreach shim,$(SHIMS),curl localhost:8081/$(shim)/hello;)
 
 integration: move-musl-to-tmp
 	cd ../.. && cargo test -- --nocapture


### PR DESCRIPTION
this commit largely removes the redundency of writing each command once for each shim this repo supports. It uses foreach syntax to iterate over each item in the shims variable and execute a command for each one.

This also applies to the CI. This commit adds a new docker-build-push action that builds and pushes the images to ghcr, abstrating the repeated build and push steps into this reusable workflow.

It also adds spin-inbound-redis and spin-outbound-redis images to the release pipeline