### PR TITLE
fix: pipeline build and push

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
     secrets:
-      GITHUB_TOKEN:
+      envPAT:
         required: true
 jobs:
   build_and_push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           path: _artifacts
       - name: create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.envPAT }}
         run: |
           gh release create ${{ env.RELEASE_VERSION }} \
             --generate-notes \
@@ -52,7 +52,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.envPAT }}
       - name: Build and push images
         uses: ./.github/workflows/build_and_push.yaml
         with:


### PR DESCRIPTION
Each execution of GH actions starts a workflow that immediately fails. It has no effect on the build itself, but pollutes the workflow list.

![image](https://github.com/deislabs/containerd-wasm-shims/assets/4034494/85d1ef3c-56d3-439b-b769-c84d072df759)

This PR renames the secret used in the reusable workflow from `GITHUB_TOKEN` to `envPAT`, since GITHUB_TOKEN is a reserved word.