### PR TITLE
feat: add -v flag to all shims

### DIFF
--- a/containerd-shim-lunatic-v1/build.rs
+++ b/containerd-shim-lunatic-v1/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+use std::str::from_utf8;
+
+fn main() {
+    let output = match Command::new("git").arg("rev-parse").arg("HEAD").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+    let mut hash = from_utf8(&output.stdout).unwrap().trim().to_string();
+
+    let output_dirty = match Command::new("git").arg("diff").arg("--exit-code").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+
+    if !output_dirty.status.success() {
+        hash.push_str(".m");
+    }
+    println!("cargo:rustc-env=CARGO_GIT_HASH={}", hash);
+}

--- a/containerd-shim-lunatic-v1/src/main.rs
+++ b/containerd-shim-lunatic-v1/src/main.rs
@@ -1,9 +1,10 @@
 use std::{
+    env,
     path::PathBuf,
     sync::{Arc, Condvar, Mutex},
 };
 
-use containerd_shim::run;
+use containerd_shim::{parse, run};
 use containerd_shim_wasm::sandbox::instance_utils::determine_rootdir;
 use containerd_shim_wasm::sandbox::stdio::Stdio;
 use containerd_shim_wasm::{
@@ -80,6 +81,20 @@ impl LibcontainerInstance for Wasi {
     }
 }
 
+fn parse_version() {
+    let os_args: Vec<_> = env::args_os().collect();
+    let flags = parse(&os_args[1..]).unwrap();
+    if flags.version {
+        println!("{}:", os_args[0].to_string_lossy());
+        println!("  Version: {}", env!("CARGO_PKG_VERSION"));
+        println!("  Revision: {}", env!("CARGO_GIT_HASH"));
+        println!();
+
+        std::process::exit(0);
+    }
+}
+
 fn main() {
+    parse_version();
     run::<ShimCli<Wasi>>("io.containerd.lunatic.v1", None);
 }

--- a/containerd-shim-slight-v1/build.rs
+++ b/containerd-shim-slight-v1/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+use std::str::from_utf8;
+
+fn main() {
+    let output = match Command::new("git").arg("rev-parse").arg("HEAD").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+    let mut hash = from_utf8(&output.stdout).unwrap().trim().to_string();
+
+    let output_dirty = match Command::new("git").arg("diff").arg("--exit-code").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+
+    if !output_dirty.status.success() {
+        hash.push_str(".m");
+    }
+    println!("cargo:rustc-env=CARGO_GIT_HASH={}", hash);
+}

--- a/containerd-shim-slight-v1/src/main.rs
+++ b/containerd-shim-slight-v1/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::option::Option;
 use std::path::PathBuf;
 
@@ -73,6 +74,20 @@ impl LibcontainerInstance for Wasi {
     }
 }
 
+fn parse_version() {
+    let os_args: Vec<_> = env::args_os().collect();
+    let flags = shim::parse(&os_args[1..]).unwrap();
+    if flags.version {
+        println!("{}:", os_args[0].to_string_lossy());
+        println!("  Version: {}", env!("CARGO_PKG_VERSION"));
+        println!("  Revision: {}", env!("CARGO_GIT_HASH"));
+        println!();
+
+        std::process::exit(0);
+    }
+}
+
 fn main() {
+    parse_version();
     shim::run::<ShimCli<Wasi>>("io.containerd.slight.v1", None);
 }

--- a/containerd-shim-spin-v1/build.rs
+++ b/containerd-shim-spin-v1/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+use std::str::from_utf8;
+
+fn main() {
+    let output = match Command::new("git").arg("rev-parse").arg("HEAD").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+    let mut hash = from_utf8(&output.stdout).unwrap().trim().to_string();
+
+    let output_dirty = match Command::new("git").arg("diff").arg("--exit-code").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+
+    if !output_dirty.status.success() {
+        hash.push_str(".m");
+    }
+    println!("cargo:rustc-env=CARGO_GIT_HASH={}", hash);
+}

--- a/containerd-shim-spin-v1/src/main.rs
+++ b/containerd-shim-spin-v1/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::option::Option;
@@ -86,7 +87,20 @@ fn parse_addr(addr: &str) -> Result<SocketAddr> {
     Ok(addrs)
 }
 
+fn parse_version() {
+    let os_args: Vec<_> = env::args_os().collect();
+    let flags = shim::parse(&os_args[1..]).unwrap();
+    if flags.version {
+        println!("{}:", os_args[0].to_string_lossy());
+        println!("  Version: {}", env!("CARGO_PKG_VERSION"));
+        println!("  Revision: {}", env!("CARGO_GIT_HASH"));
+        println!();
+        std::process::exit(0);
+    }
+}
+
 fn main() {
+    parse_version();
     shim::run::<ShimCli<Wasi>>("io.containerd.spin.v1", None);
 }
 

--- a/containerd-shim-wws-v1/build.rs
+++ b/containerd-shim-wws-v1/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+use std::str::from_utf8;
+
+fn main() {
+    let output = match Command::new("git").arg("rev-parse").arg("HEAD").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+    let mut hash = from_utf8(&output.stdout).unwrap().trim().to_string();
+
+    let output_dirty = match Command::new("git").arg("diff").arg("--exit-code").output() {
+        Ok(output) => output,
+        Err(_) => {
+            return;
+        }
+    };
+
+    if !output_dirty.status.success() {
+        hash.push_str(".m");
+    }
+    println!("cargo:rustc-env=CARGO_GIT_HASH={}", hash);
+}

--- a/containerd-shim-wws-v1/src/main.rs
+++ b/containerd-shim-wws-v1/src/main.rs
@@ -8,6 +8,7 @@ use executor::WwsExecutor;
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::container::Container;
 use libcontainer::syscall::syscall::SyscallType;
+use std::env;
 use std::option::Option;
 use std::path::PathBuf;
 
@@ -84,6 +85,20 @@ impl LibcontainerInstance for Workers {
     }
 }
 
+fn parse_version() {
+    let os_args: Vec<_> = env::args_os().collect();
+    let flags = shim::parse(&os_args[1..]).unwrap();
+    if flags.version {
+        println!("{}:", os_args[0].to_string_lossy());
+        println!("  Version: {}", env!("CARGO_PKG_VERSION"));
+        println!("  Revision: {}", env!("CARGO_GIT_HASH"));
+        println!();
+
+        std::process::exit(0);
+    }
+}
+
 fn main() {
+    parse_version();
     shim::run::<ShimCli<Workers>>("io.containerd.wws.v1", None);
 }


### PR DESCRIPTION
This commit follows https://github.com/containerd/runwasi/pull/268 to add `--version` or `-v` flag to all the shims.