### PR TITLE
CI: add image docker build to the build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  build-wasm-images:
+    uses: ./.github/workflows/docker-build-push.yaml
+    with:
+      push: false
   build:
     runs-on: ${{ matrix.config.os }}
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,10 +4,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  build-wasm-images:
-    uses: ./.github/workflows/docker-build-push.yaml
-    with:
-      push: false
   build:
     runs-on: ${{ matrix.config.os }}
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
   build-wasm-images:
     uses: ./.github/workflows/docker-build-push.yaml
     with:
-      push: false
+      test: true
   build:
     uses: ./.github/workflows/build.yaml
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: fmt
         run: |
           make fmt
+  build-wasm-images:
+    uses: ./.github/workflows/docker-build-push.yaml
+    with:
+      push: false
   build:
     uses: ./.github/workflows/build.yaml
   test:

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,7 +1,11 @@
 name: 'Build and push Docker images'
 on:
   workflow_call:
-
+    inputs:
+      push:
+        description: 'Push the image to the registry'
+        type: boolean
+        required: true
 jobs:
   build_and_push:
     permissions:
@@ -49,9 +53,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
-          push: true
+          push: ${{ inputs.push }}
           tags: |
             ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:${{ env.RELEASE_VERSION }}
             ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:latest

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -2,8 +2,8 @@ name: 'Build and push Docker images'
 on:
   workflow_call:
     inputs:
-      push:
-        description: 'Push the image to the registry'
+      test:
+        description: 'Is this a test run?'
         type: boolean
         required: true
 jobs:
@@ -52,10 +52,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: test
+        uses: docker/build-push-action@v4
+        if: ${{ inputs.test == 'true' }}
+        with:
+          context: ${{ matrix.image.context }}
+          load: true
+          tags: containerd-wasm-shims${{ matrix.image.imageName }}:test
+          platforms: wasi/wasm
       - name: build and push
         uses: docker/build-push-action@v4
+        if: ${{ inputs.test == 'false' }}
         with:
-          push: ${{ inputs.push }}
+          push: true
           tags: |
             ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:${{ env.RELEASE_VERSION }}
             ghcr.io/deislabs/containerd-wasm-shims/${{ matrix.image.imageName }}:latest

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: test
         uses: docker/build-push-action@v4
-        if: ${{ inputs.test == 'true' }}
+        if: ${{ inputs.test }}
         with:
           context: ${{ matrix.image.context }}
           load: true
@@ -62,7 +62,7 @@ jobs:
           platforms: wasi/wasm
       - name: build and push
         uses: docker/build-push-action@v4
-        if: ${{ inputs.test == 'false' }}
+        if: ${{ !inputs.test }}
         with:
           push: true
           tags: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
   build-and-push-wasm-images:
     uses: ./.github/workflows/docker-build-push.yaml
     with:
-      push: true
+      test: false
 
   release:
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
 
   build-and-push-wasm-images:
     uses: ./.github/workflows/docker-build-push.yaml
+    with:
+      push: true
 
   release:
     permissions:


### PR DESCRIPTION
This commit adds a new job to the `build` workflow to verify all the wasm images could be built in Docker. This sets the `push` parameter to false in `build` so that images will not be uploaded. 