### PR TITLE
fix: add cgroup v1 support

### DIFF
--- a/containerd-shim-lunatic-v1/Cargo.toml
+++ b/containerd-shim-lunatic-v1/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 containerd-shim = "0.5.0"
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "7e978edeaf34b54efb895738357c805cf888b76d", features = ["cgroupsv2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v2"], default-features = false }
+libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v1","v2"], default-features = false }
 nix = "0.26.2"
 serde = "1.0.183"
 serde_json = "1.0.104"

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -15,7 +15,7 @@ chrono = "0.4"
 clap = { version = "4.1", features = ["derive", "env"] }
 containerd-shim = "0.5.0"
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "7e978edeaf34b54efb895738357c805cf888b76d", features = ["cgroupsv2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v2"], default-features = false }
+libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v1","v2"], default-features = false }
 log = "0.4"
 tokio = { version = "1", features = [ "full" ] }
 tokio-util = { version = "0.7", features = [ "codec" ]}

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -15,7 +15,7 @@ chrono = "0.4"
 clap = { version = "4.3", features = ["derive", "env"] }
 containerd-shim = "0.5.0"
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "7e978edeaf34b54efb895738357c805cf888b76d", features = ["cgroupsv2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v2"], default-features = false }
+libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v1","v2"], default-features = false }
 log = "0.4"
 spin-trigger = { git = "https://github.com/fermyon/spin", tag = "v1.4.1" }
 spin-app = { git = "https://github.com/fermyon/spin", tag = "v1.4.1" }

--- a/containerd-shim-wws-v1/Cargo.toml
+++ b/containerd-shim-wws-v1/Cargo.toml
@@ -15,7 +15,7 @@ Containerd shim for running Wasm Workers Server workloads.
 [dependencies]
 containerd-shim = "0.5.0"
 containerd-shim-wasm = { git = "https://github.com/containerd/runwasi", rev = "7e978edeaf34b54efb895738357c805cf888b76d", features = ["cgroupsv2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v2"], default-features = false }
+libcontainer = { git = "https://github.com/containers/youki", rev = "09e67372a892f22a89eeef62ff429c3cbcac6d41", features = ["v1","v2"], default-features = false }
 wasm-workers-server = { git = "https://github.com/vmware-labs/wasm-workers-server", tag = "v1.5.0" }
 log = "0.4"
 tokio = { version = "1", features = [ "full" ] }


### PR DESCRIPTION
This PR enables the "v1" feature for libcontainer to support K8s distributions such as CoLima and Civo K3s.
fixes: https://github.com/containerd/runwasi/issues/288#issuecomment-1707764979