### PR TITLE
fix: CI for k3d arm64 image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
 
       # Setup buildx to build multiarch image: https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to GitHub container registry
@@ -61,12 +61,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       
       # Build and push k3d shim image
-      - name: untar x86_64 musl artifacts into ./deployments/k3d/.tmp dir
+      - name: untar musl artifacts into ./deployments/k3d/.tmp/linux/(amd64|arm64) dir
         run: |
-          mkdir -p ./deployments/k3d/.tmp
-          for f in ./_artifacts/*/*-x86_64.tar.gz; do tar -xf $f --directory ./deployments/k3d/.tmp; done
+          mkdir -p ./deployments/k3d/.tmp/linux/amd64
+          mkdir -p ./deployments/k3d/.tmp/linux/arm64
+          for f in ./_artifacts/*/*-x86_64.tar.gz; do tar -xf $f --directory ./deployments/k3d/.tmp/linux/amd64; done
+          for f in ./_artifacts/*/*-aarch64.tar.gz; do tar -xf $f --directory ./deployments/k3d/.tmp/linux/arm64; done
       - name: build and push k3d shim image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: |
@@ -74,6 +76,8 @@ jobs:
             ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:latest
           context: deployments/k3d
           platforms: linux/amd64,linux/arm64
+          build-args:
+            - STAGE=release
       - name: clear
         if: always()
         run: |

--- a/deployments/k3d/Dockerfile
+++ b/deployments/k3d/Dockerfile
@@ -1,7 +1,18 @@
+ARG STAGE="test"
+
+FROM scratch AS bin-test
+COPY ./.tmp /
+
+FROM scratch AS bin-release
+ARG TARGETPLATFORM
+COPY ./.tmp/${TARGETPLATFORM} /
+
+FROM bin-${STAGE} AS bin
+
 FROM rancher/k3s:v1.24.6-k3s1
 
 # copy shims from target directory into the /bin
-COPY ./.tmp /bin/
+COPY --link --from=bin / /bin/
 
 # copy in an containerd config into /etc/containerd/config.toml
 COPY config.toml.tmpl /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl


### PR DESCRIPTION
This PR changes the release pipeline to produce K3d images where the binaries match the image architecture.
fixes: #147