### PR TITLE
chore: bump version to v0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/containerd-shim-lunatic-v1/Cargo.lock
+++ b/containerd-shim-lunatic-v1/Cargo.lock
@@ -3845,7 +3845,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "oci-spec",

--- a/containerd-shim-slight-v1/Cargo.lock
+++ b/containerd-shim-slight-v1/Cargo.lock
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-slight-v1"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5970,7 +5970,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "oci-spec",

--- a/containerd-shim-slight-v1/Cargo.toml
+++ b/containerd-shim-slight-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-slight-v1"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/containerd-shim-spin-v1/Cargo.lock
+++ b/containerd-shim-spin-v1/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-spin-v1"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5144,7 +5144,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "oci-spec",

--- a/containerd-shim-spin-v1/Cargo.toml
+++ b/containerd-shim-spin-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-spin-v1"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/containerd-shim-wws-v1/Cargo.lock
+++ b/containerd-shim-wws-v1/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wws-v1"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3786,7 +3786,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "oci-spec",

--- a/containerd-shim-wws-v1/Cargo.toml
+++ b/containerd-shim-wws-v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wws-v1"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Wasm Labs team <wasmlabs@vmware.com>"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -17,7 +17,7 @@ $ tree .
 ## How to run the example
 The shell script below will create a k3d cluster locally with the Wasm shims installed and containerd configured. The script then applies the runtime classes for the shims and an example service and deployment. Finally, we curl the `/hello` and receive a response from the example workload.
 ```shell
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.9.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.9.1 -p "8081:80@loadbalancer" --agents 2
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/raw/main/deployments/workloads/runtime.yaml
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/raw/main/deployments/workloads/workload.yaml
 echo "waiting 5 seconds for workload to be ready"

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -15,7 +15,7 @@ spec:
       runtimeClassName: wasmtime-slight
       containers:
         - name: slight-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.9.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.9.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -54,7 +54,7 @@ spec:
       runtimeClassName: wasmtime-spin
       containers:
         - name: spin-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.9.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.9.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -93,7 +93,7 @@ spec:
       runtimeClassName: wasmtime-wws
       containers:
         - name: wws-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:v0.9.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:v0.9.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -132,7 +132,7 @@ spec:
       runtimeClassName: wasmtime-lunatic
       containers:
         - name: lunatic
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/lunatic-submillisecond:v0.9.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/lunatic-submillisecond:v0.9.1
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
               cpu: 100m

--- a/images/slight/Cargo.toml
+++ b/images/slight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server-lib"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/images/spin-outbound-redis/Cargo.toml
+++ b/images/spin-outbound-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-outbound-redis"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 

--- a/images/spin/Cargo.toml
+++ b/images/spin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-rust-hello"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 


### PR DESCRIPTION
Prepare for the release of `v0.9.1` by #154 