### PR TITLE
revert docker build-push-action back to v3

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -61,7 +61,9 @@ jobs:
           tags: containerd-wasm-shims${{ matrix.image.imageName }}:test
           platforms: wasi/wasm
       - name: build and push
-        uses: docker/build-push-action@v4
+        # we use v3 here because we can't push wasi/wasm images with v4
+        # see https://github.com/deislabs/containerd-wasm-shims/issues/154#issuecomment-1726030749
+        uses: docker/build-push-action@v3
         if: ${{ !inputs.test }}
         with:
           push: true


### PR DESCRIPTION
This commits revert #146's change that updated "docker/build-push-action" from `v3` to `v4`. This is because the new images being pushed to ghci don't have Linux/amd64 platforms anymore, which then can't be pulled by Kubernetes. Note that this isn't a long term solution. 

After this PR merges, I will do another release of `v0.9.1`

CC @0xE282B0 @jprendes