### PR TITLE
fix(*): replace deprecated ingress annotation

### DIFF
--- a/containerd-shim-slight/quickstart.md
+++ b/containerd-shim-slight/quickstart.md
@@ -178,8 +178,8 @@ metadata:
   name: wasm-slight
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/containerd-shim-spin/quickstart.md
+++ b/containerd-shim-spin/quickstart.md
@@ -211,8 +211,8 @@ metadata:
   name: wasm-spin
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/containerd-shim-wws/quickstart.md
+++ b/containerd-shim-wws/quickstart.md
@@ -176,8 +176,8 @@ metadata:
   name: wasm-wws
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/deployments/chat-workloads/workload.yaml
+++ b/deployments/chat-workloads/workload.yaml
@@ -82,8 +82,8 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/deployments/k3d/workload/workload.yaml
+++ b/deployments/k3d/workload/workload.yaml
@@ -156,9 +156,9 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.middlewares: default-strip-prefix@kubernetescrd
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -174,9 +174,9 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.middlewares: default-strip-prefix@kubernetescrd
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:

--- a/tests/workloads/workload.yaml
+++ b/tests/workloads/workload.yaml
@@ -261,9 +261,9 @@ metadata:
   name: wasm-ingress
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
     traefik.ingress.kubernetes.io/router.middlewares: default-strip-prefix@kubernetescrd
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:


### PR DESCRIPTION
Noticed a deprecation warning around the ingress annotation when running the shim via k3s. (`Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead`)

Updated applicable manifests per https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation