### PR TITLE
chore(k3d/Dockerfile): bump rancher/k3s base image

### DIFF
--- a/deployments/k3d/Dockerfile
+++ b/deployments/k3d/Dockerfile
@@ -9,7 +9,7 @@ COPY ./.tmp/${TARGETPLATFORM} /
 
 FROM bin-${STAGE} AS bin
 
-FROM rancher/k3s:v1.27.4-k3s1
+FROM rancher/k3s:v1.27.8-k3s2
 
 # copy shims from target directory into the /bin
 COPY --link --from=bin / /bin/


### PR DESCRIPTION
- Bumps the rancher/k3s base image to [v1.27.8-k3s2](https://github.com/k3s-io/k3s/releases/tag/v1.27.8+k3s2).

The goal is mainly to inherit a v1.7.7+ version of containerd to get the OCI support mentioned in https://github.com/deislabs/containerd-wasm-shims/issues/191#issuecomment-1834436484.  I chose a release still in the 1.27x range for k8s but there are 1.28 versions as well.  Definitely open to suggestions on the actual version to bump to, assuming we're able to bump.

Caveat: I haven't been able to build this image and its dependencies locally -- may need pointers on how to best set up a cross-compilation env (I'm on Mac/Apple Silicon).  I was hoping I could lean on CI or a kind volunteer to help verify this version is working as intended 😅