### PR TITLE
ci: enable containerd image store for docker

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -52,6 +52,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: enable containerd image store
+        run: |
+          echo '{ "features": { "containerd-snapshotter": true } }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info -f '{{ .DriverStatus }}'
       - name: test
         uses: docker/build-push-action@v4
         if: ${{ inputs.test }}


### PR DESCRIPTION
Close #205

The containerd image store is required to load wasi/wasm images. For more info about the image store, you can read it [here](https://docs.docker.com/desktop/containerd/#what-is-the-containerd-image-store).

Regarding how to enable the image store in docker, please refer to this [page](https://docs.docker.com/storage/containerd/#enable-containerd-image-store-on-docker-engine).