### PR TITLE
chore(*): bump to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-wasm-shims-tests"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/containerd-shim-lunatic/Cargo.lock
+++ b/containerd-shim-lunatic/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-lunatic-v1"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/containerd-shim-lunatic/Cargo.toml
+++ b/containerd-shim-lunatic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-lunatic-v1"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/containerd-shim-slight/Cargo.lock
+++ b/containerd-shim-slight/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-slight-v1"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "containerd-shim-wasm",

--- a/containerd-shim-slight/Cargo.toml
+++ b/containerd-shim-slight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-slight-v1"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/containerd-shim-spin/Cargo.lock
+++ b/containerd-shim-spin/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-spin-v2"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "containerd-shim-wasm",

--- a/containerd-shim-spin/Cargo.toml
+++ b/containerd-shim-spin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-spin-v2"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/containerd-shim-spin/quickstart.md
+++ b/containerd-shim-spin/quickstart.md
@@ -14,7 +14,7 @@ Before you begin, you need to have the following installed:
 Start a k3d cluster with the wasm shims already installed:
 
 ```bash
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
+k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.1 -p "8081:80@loadbalancer" --agents 2 --registry-create mycluster-registry:12345
 ```
 
 Apply RuntimeClass for spin applications to use the spin wasm shim:

--- a/containerd-shim-wws/Cargo.lock
+++ b/containerd-shim-wws/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wws-v1"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "containerd-shim-wasm",

--- a/containerd-shim-wws/Cargo.toml
+++ b/containerd-shim-wws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wws-v1"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Wasm Labs team <wasmlabs@vmware.com>"]
 edition = "2021"
 repository = 'https://github.com/deislabs/containerd-wasm-shims'

--- a/deployments/k3d/README.md
+++ b/deployments/k3d/README.md
@@ -17,7 +17,7 @@ $ tree .
 ## How to run the example
 The shell script below will create a k3d cluster locally with the Wasm shims installed and containerd configured. The script then applies the runtime classes for the shims and an example service and deployment. Finally, we curl the `/hello` and receive a response from the example workload.
 ```shell
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer" --agents 2
+k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.1 -p "8081:80@loadbalancer" --agents 2
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/raw/main/deployments/workloads/runtime.yaml
 kubectl apply -f https://github.com/deislabs/containerd-wasm-shims/raw/main/deployments/workloads/workload.yaml
 echo "waiting 5 seconds for workload to be ready"

--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -15,7 +15,7 @@ spec:
       runtimeClassName: wasmtime-slight
       containers:
         - name: slight-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.11.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.11.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -54,7 +54,7 @@ spec:
       runtimeClassName: wasmtime-spin
       containers:
         - name: spin-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.11.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -93,7 +93,7 @@ spec:
       runtimeClassName: wasmtime-wws
       containers:
         - name: wws-hello
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:v0.11.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/wws-js-hello:v0.11.1
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
@@ -132,7 +132,7 @@ spec:
       runtimeClassName: wasmtime-lunatic
       containers:
         - name: lunatic
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/lunatic-submillisecond:v0.11.0
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/lunatic-submillisecond:v0.11.1
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:
               cpu: 100m

--- a/images/slight/Cargo.toml
+++ b/images/slight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-server-lib"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/images/spin-dapr/README.md
+++ b/images/spin-dapr/README.md
@@ -18,7 +18,7 @@ sudo mv ./spin /usr/local/bin/
 ### Run example with K3d:
 ```sh
 # start the K3d cluster
-k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.0 -p "8081:80@loadbalancer"  
+k3d cluster create wasm-cluster --image ghcr.io/deislabs/containerd-wasm-shims/examples/k3d:v0.11.1 -p "8081:80@loadbalancer"  
 # Install Dapr
 dapr init -k --wait
 # or via helm

--- a/images/spin-inbound-redis/Cargo.toml
+++ b/images/spin-inbound-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-inbound-redis"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Suneet Nangia <suneetnangia@gmail.com>"]
 edition = "2021"
 

--- a/images/spin-outbound-redis/Cargo.toml
+++ b/images/spin-outbound-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-outbound-redis"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 

--- a/images/spin/Cargo.toml
+++ b/images/spin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-rust-hello"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["DeisLabs Engineering Team"]
 edition = "2021"
 


### PR DESCRIPTION
This bumps the crate versions and workloads to `v0.11.1` 